### PR TITLE
Clean up JEI

### DIFF
--- a/config/MoreDefaultOptions/options.txt
+++ b/config/MoreDefaultOptions/options.txt
@@ -2,7 +2,7 @@ version:1343
 invertYMouse:false
 mouseSensitivity:0.5
 fov:0.0
-gamma:1.0
+gamma:0.0
 saturation:0.0
 renderDistance:7
 guiScale:3

--- a/config/enderio/enderiomachines.cfg
+++ b/config/enderio/enderiomachines.cfg
@@ -325,22 +325,22 @@ niard {
 
 personal {
     B:enableAlloySmelterAlloyingJEI=true
-    B:enableAlloySmelterFurnaceJEI=true
+    B:enableAlloySmelterFurnaceJEI=false
     B:enableCombustionGenJEI=true
     B:enableEnchanterJEI=true
     B:enableEnderGenJEI=true
     B:enableGrindingBallsJEI=true
     B:enableLavaGeneratorJEI=true
-    B:enablePainterJEI=true
+    B:enablePainterJEI=false
     B:enableSliceAndSpliceJEI=true
     B:enableSolarJEI=true
     B:enableSoulBinderJEI=true
     B:enableStirlingGenJEI=true
-    B:enableTankFluidInOutJEI=true
-    B:enableTankMendingJEI=true
+    B:enableTankFluidInOutJEI=false
+    B:enableTankMendingJEI=false
     B:enableVatJEI=true
     B:enableWeatherObeliskJEI=true
-    B:enableWiredChargerJEI=true
+    B:enableWiredChargerJEI=false
     B:enableZombieGenJEI=true
 }
 

--- a/config/waila/waila.cfg
+++ b/config/waila/waila.cfg
@@ -21,7 +21,7 @@ general {
     B:waila.cfg.keybind=true
     B:waila.cfg.liquid=true
     I:waila.cfg.maxhpbeforetext=40
-    B:waila.cfg.metadata=true
+    B:waila.cfg.metadata=false
     S:waila.cfg.metadataformat=\u00A77[%s@%d]
     S:waila.cfg.modnameformat=\u00A79\u00A7o%s
     B:waila.cfg.newfilters=true

--- a/scripts/mods/jei.zs
+++ b/scripts/mods/jei.zs
@@ -10,7 +10,6 @@ var categoriesToHide as string[] = [
 	"thermalexpansion.furnace",
 	"thermalexpansion.factorizer_combine",
 	"thermalexpansion.factorizer_split",
-	"Painter",
 	"forestry.bottler",
 	"ic2.scrapbox",
 	"xu2_machine_extrautils2:furnace",
@@ -19,7 +18,9 @@ var categoriesToHide as string[] = [
   "mctsmelteryio:casting_machine",
   "mctsmelteryio:fuel_controller",
 	"tcomplement:high_oven_melting",
-	"mekanism.energizedsmelter"
+	"mekanism.energizedsmelter",
+	"jeresources.enchantment",
+	"oc.manual"
 ];
 
 for category in categoriesToHide {


### PR DESCRIPTION
Ender IO alloy smelter doesnt need to show furnace recipes
Wired charger recipes are just add RF
Painter recipes now don't load in JEI vs. just hiding it
OpenComputers Manual in JEI is pretty much useless
Enchantments tab is annoying
Tank is just fill/empty and mending

don't have to include all of these