### PR TITLE
Reducing the number of columns in JEI

### DIFF
--- a/config/jei/jei.cfg
+++ b/config/jei/jei.cfg
@@ -25,7 +25,7 @@ advanced {
     S:giveMode=inventory
 
     # The maximum width of the ingredient list. [range: 4 ~ 100, default: 100]
-    I:maxColumns=100
+    I:maxColumns=10
 
     # The maximum height of the recipe GUI. [range: 175 ~ 5000, default: 350]
     I:maxRecipeGuiHeight=350


### PR DESCRIPTION
Clears inventory visually while keeping a reasonable number of items displayed at high DPI. As a bonus, it allows you to get rid of inventory lag when heavy models are displayed on the page.