### PR TITLE
Add Vacuumulator to carryon blacklist.

### DIFF
--- a/config/carryon.cfg
+++ b/config/carryon.cfg
@@ -124,6 +124,7 @@ general {
 
         # Tile Entities that cannot be picked up
         S:forbiddenTiles <
+            thermalexpansion:device:12
             advancedrocketry:rocket
             aeadditions:*
             animania:block_invisiblock


### PR DESCRIPTION
due to carryon, it can be difficult to set up an filter in the vacuumulator if  you are using default keybinds.