### PR TITLE
🔄 Add [Vaccumulator] blacklist to carryon

### DIFF
--- a/config/carryon.cfg
+++ b/config/carryon.cfg
@@ -125,6 +125,7 @@ general {
 
         # Tile Entities that cannot be picked up
         S:forbiddenTiles <
+            thermalexpansion:device;12
             aeadditions:*
             animania:block_invisiblock
             animania:block_trough


### PR DESCRIPTION
Creating an new pr since the old one didn't work, fixes #130
What i did wrong is that instead of an ; i digited an : 
and the carryon config file works like this:
![image](https://user-images.githubusercontent.com/113219956/197630823-e72b0994-cf92-4b9a-ac44-fce40b2e6951.png)
(id;meta)
**Sorry for the incovenience**