### PR TITLE
Nerf pokeballs draft

### DIFF
--- a/resources/enigmatica/lang/en_us.lang
+++ b/resources/enigmatica/lang/en_us.lang
@@ -22,6 +22,8 @@ e2ee.written_book.Zombie=Zombie
 e2ee.eu2_drum_error=§7You must have at least 1 empty inventory slot to do this
 e2ee.danknull_dock.must_have=§7You need a §f%s§7 in the offhand to insert %s§7 into %s§7. §f%s§7 will be irreversibly consumed.
 e2ee.restrict.vis_seeds=§7§eVis Seeds§7 can only be planted in §nthe Void§7 dimension or on §nplanets§7. They also need Oxygen.
+e2ee.creature_resisted_morb=This creature is strong enough to resist capture by the %s.
+tooltips.lang.morb_resist=Effective against monsters at < 30% hearts, or with fewer than 4 hearts total.
 
 # Bugged langs that losed their names
 entity.Villager.shady_merchant=Shady Merchant

--- a/resources/enigmatica/lang/en_us.lang
+++ b/resources/enigmatica/lang/en_us.lang
@@ -24,7 +24,7 @@ e2ee.danknull_dock.must_have=§7You need a §f%s§7 in the offhand to insert %s�
 e2ee.restrict.vis_seeds=§7§eVis Seeds§7 can only be planted in §nthe Void§7 dimension or on §nplanets§7. They also need Oxygen.
 e2ee.creature_resisted_morb=This creature is strong enough to resist capture by the %s.
 e2ee.creature_uncapturable=This creature can't be captured.
-tooltips.lang.morb_resist=Effective against monsters at < 30% hearts, or with fewer than 4 hearts total.
+tooltips.lang.morb_resist=Effective against monsters at < %s%% hearts, or with fewer than %s hearts total.
 
 # Bugged langs that losed their names
 entity.Villager.shady_merchant=Shady Merchant

--- a/resources/enigmatica/lang/en_us.lang
+++ b/resources/enigmatica/lang/en_us.lang
@@ -23,6 +23,7 @@ e2ee.eu2_drum_error=§7You must have at least 1 empty inventory slot to do this
 e2ee.danknull_dock.must_have=§7You need a §f%s§7 in the offhand to insert %s§7 into %s§7. §f%s§7 will be irreversibly consumed.
 e2ee.restrict.vis_seeds=§7§eVis Seeds§7 can only be planted in §nthe Void§7 dimension or on §nplanets§7. They also need Oxygen.
 e2ee.creature_resisted_morb=This creature is strong enough to resist capture by the %s.
+e2ee.creature_uncapturable=This creature can't be captured.
 tooltips.lang.morb_resist=Effective against monsters at < 30% hearts, or with fewer than 4 hearts total.
 
 # Bugged langs that losed their names

--- a/resources/enigmatica/lang/en_us.lang
+++ b/resources/enigmatica/lang/en_us.lang
@@ -22,9 +22,9 @@ e2ee.written_book.Zombie=Zombie
 e2ee.eu2_drum_error=§7You must have at least 1 empty inventory slot to do this
 e2ee.danknull_dock.must_have=§7You need a §f%s§7 in the offhand to insert %s§7 into %s§7. §f%s§7 will be irreversibly consumed.
 e2ee.restrict.vis_seeds=§7§eVis Seeds§7 can only be planted in §nthe Void§7 dimension or on §nplanets§7. They also need Oxygen.
-e2ee.creature_resisted_morb=This creature is strong enough to resist capture by the %s.
-e2ee.creature_uncapturable=This creature can't be captured.
-tooltips.lang.morb_resist=Effective against monsters at < %s%% hearts, or with fewer than %s hearts total.
+e2ee.creature_resisted_morb=§8This creature is strong enough to resist capture by the §n%s.
+e2ee.creature_uncapturable=§7This creature can't be captured.
+tooltips.lang.morb_resist=Effective against monsters at §4< %s%%§r hearts, or with fewer than §c%s§r hearts total.
 
 # Bugged langs that losed their names
 entity.Villager.shady_merchant=Shady Merchant

--- a/resources/enigmatica/lang/ru_ru.lang
+++ b/resources/enigmatica/lang/ru_ru.lang
@@ -23,6 +23,7 @@ e2ee.eu2_drum_error=§7Для этого у вас должен быть как 
 e2ee.danknull_dock.must_have=§7Вам понадобится §f%s§r в свободной руке, для того, чтобы вставить %s в %s. §f%s§r будет необратимо израсходован.
 e2ee.restrict.vis_seeds=§7Вы можете сажать §6Семена Вис§7 только в §nМире пустоты§r§7 или на §nпланетах§r§7. Им также необходим кислород.
 e2ee.creature_resisted_morb=Существо сопротивлялось захвату %s.
+e2ee.creature_uncapturable=Это существо нельзя поймать.
 tooltips.lang.morb_resist=Эффективен против монстров с менее чем 30% сердец или менее 4 сердец.
 
 # Bugged langs that losed their names

--- a/resources/enigmatica/lang/ru_ru.lang
+++ b/resources/enigmatica/lang/ru_ru.lang
@@ -22,9 +22,9 @@ e2ee.written_book.Zombie=Зомби
 e2ee.eu2_drum_error=§7Для этого у вас должен быть как минимум 1 пустой слот в инвентаре
 e2ee.danknull_dock.must_have=§7Вам понадобится §f%s§r в свободной руке, для того, чтобы вставить %s в %s. §f%s§r будет необратимо израсходован.
 e2ee.restrict.vis_seeds=§7Вы можете сажать §6Семена Вис§7 только в §nМире пустоты§r§7 или на §nпланетах§r§7. Им также необходим кислород.
-e2ee.creature_resisted_morb=Существо сопротивлялось захвату %s.
-e2ee.creature_uncapturable=Это существо нельзя поймать.
-tooltips.lang.morb_resist=Эффективен против монстров с менее чем %s%% сердец или менее %s сердец.
+e2ee.creature_resisted_morb=§8Существо сопротивлялось захвату §n%s.
+e2ee.creature_uncapturable=§7Это существо нельзя поймать.
+tooltips.lang.morb_resist=Эффективен против монстров с §4< %s%%§r сердец или менее §c%s§r сердец.
 
 # Bugged langs that losed their names
 entity.Villager.shady_merchant=Тенистый торговец

--- a/resources/enigmatica/lang/ru_ru.lang
+++ b/resources/enigmatica/lang/ru_ru.lang
@@ -24,7 +24,7 @@ e2ee.danknull_dock.must_have=§7Вам понадобится §f%s§r в сво
 e2ee.restrict.vis_seeds=§7Вы можете сажать §6Семена Вис§7 только в §nМире пустоты§r§7 или на §nпланетах§r§7. Им также необходим кислород.
 e2ee.creature_resisted_morb=Существо сопротивлялось захвату %s.
 e2ee.creature_uncapturable=Это существо нельзя поймать.
-tooltips.lang.morb_resist=Эффективен против монстров с менее чем 30% сердец или менее 4 сердец.
+tooltips.lang.morb_resist=Эффективен против монстров с менее чем %s%% сердец или менее %s сердец.
 
 # Bugged langs that losed their names
 entity.Villager.shady_merchant=Тенистый торговец

--- a/resources/enigmatica/lang/ru_ru.lang
+++ b/resources/enigmatica/lang/ru_ru.lang
@@ -22,6 +22,8 @@ e2ee.written_book.Zombie=Зомби
 e2ee.eu2_drum_error=§7Для этого у вас должен быть как минимум 1 пустой слот в инвентаре
 e2ee.danknull_dock.must_have=§7Вам понадобится §f%s§r в свободной руке, для того, чтобы вставить %s в %s. §f%s§r будет необратимо израсходован.
 e2ee.restrict.vis_seeds=§7Вы можете сажать §6Семена Вис§7 только в §nМире пустоты§r§7 или на §nпланетах§r§7. Им также необходим кислород.
+e2ee.creature_resisted_morb=Существо сопротивлялось захвату %s.
+tooltips.lang.morb_resist=Эффективен против монстров с менее чем 30% сердец или менее 4 сердец.
 
 # Bugged langs that losed their names
 entity.Villager.shady_merchant=Тенистый торговец

--- a/scripts/category/tooltips.zs
+++ b/scripts/category/tooltips.zs
@@ -401,3 +401,8 @@ for lang, items in {
 		desc.jei(item, lang);
 	}
 }
+
+#morb-like items limitation hint
+desc.jei(<thermalexpansion:morb:*>, "morb_resist");
+desc.jei(<cyclicmagic:magic_net>, "morb_resist");
+

--- a/scripts/category/tooltips.zs
+++ b/scripts/category/tooltips.zs
@@ -401,8 +401,3 @@ for lang, items in {
 		desc.jei(item, lang);
 	}
 }
-
-#morb-like items limitation hint
-desc.jei(<thermalexpansion:morb:*>, "morb_resist");
-desc.jei(<cyclicmagic:magic_net>, "morb_resist");
-

--- a/scripts/do/throw_morb.zs
+++ b/scripts/do/throw_morb.zs
@@ -20,6 +20,10 @@ import crafttweaker.text.ITextComponent.fromTranslation;
 static hpPortionTreshold as double = 0.3;
 static ignoredHealth as double = 8.0;
 
+// morb-like items limitation hint
+scripts.category.tooltip_utils.desc.both(<thermalexpansion:morb:*>, "morb_resist", hpPortionTreshold * 100, ignoredHealth / 2);
+scripts.category.tooltip_utils.desc.both(<cyclicmagic:magic_net>  , "morb_resist", hpPortionTreshold * 100, ignoredHealth / 2);
+
 static uncapturables as IEntityDefinition[] = [
 /*Inject_js(
   config('config/cofh/thermalexpansion/morbs.cfg')

--- a/scripts/do/throw_morb.zs
+++ b/scripts/do/throw_morb.zs
@@ -1,8 +1,10 @@
 import crafttweaker.entity.IEntityLivingBase;
 import crafttweaker.player.IPlayer;
+import crafttweaker.entity.IEntityDefinition;
+import crafttweaker.text.ITextComponent.fromTranslation;
 
 #loader crafttweaker reloadableevents
-   
+
 events.onProjectileImpactThrowable(function(e as crafttweaker.event.ProjectileImpactThrowableEvent){
 	
 	if (isNull(e.thrower)||
@@ -26,12 +28,60 @@ events.onProjectileImpactThrowable(function(e as crafttweaker.event.ProjectileIm
 	val pokemon as IEntityLivingBase=e.rayTrace.entity;
 	
 	if pokemon.maxHealth==0 return;
-	    
+
+	val uncapturables=[<entity:iceandfire:cyclops>,
+			   <entity:iceandfire:deathwormegg>,
+			   <entity:iceandfire:dragonegg>,
+			   <entity:iceandfire:dragonskull>,
+			   <entity:iceandfire:firedragon>,
+			   <entity:iceandfire:gorgon>,
+			   <entity:iceandfire:hippogryphegg>,
+			   <entity:iceandfire:icedragon>,
+			   <entity:iceandfire:if_cockatriceegg>,
+			   <entity:iceandfire:if_mob_skull>,
+			   <entity:iceandfire:myrmex_egg>,
+			   <entity:iceandfire:myrmex_queen>,
+			   <entity:iceandfire:stonestatue>,
+			   <entity:iceandfire:tide_trident>,
+			   <entity:botania:doppleganger>,
+			   <entity:draconicevolution:guardiancrystal>,
+			   <entity:extrabotany:gaiaiii>,
+			   <entity:extrabotany:voidherrscher>,
+			   <entity:minecraft:ender_dragon>,
+			   <entity:minecraft:evocation_illager>,
+			   <entity:minecraft:vindication_illager>,
+			   <entity:minecraft:wither>,
+			   <entity:twilightforest:armored_giant>,
+			   <entity:twilightforest:armored_giant>,
+			   <entity:twilightforest:giant_miner>,
+			   <entity:twilightforest:giant_miner>,
+			   <entity:twilightforest:hydra>,
+			   <entity:twilightforest:knight_phantom>,
+			   <entity:twilightforest:lich>,
+			   <entity:twilightforest:minoshroom>,
+			   <entity:twilightforest:naga>,
+			   <entity:twilightforest:snow_queen>,
+			   <entity:twilightforest:ur_ghast>,
+			   <entity:twilightforest:yeti_alpha>] as IEntityDefinition[];
+
+	var capturable=true;
+	for ii in uncapturables {
+		if(isNull(ii)||isNull(ii.id)){
+		    continue;
+		}
+		if (pokemon.definition.id==ii.id){
+		    capturable=false;
+		    break;
+		}
+	    }
+
+	
 	val hpPortion=pokemon.health/pokemon.maxHealth;
-	if ( hpPortion > 0.3 && pokemon.health > 8){
+	if ( !capturable || (hpPortion > 0.3 && pokemon.health > 8) ){
 	    
 	    //TODO find correct localized displayName for entity, not pokemon.definition.name
-	    val message = crafttweaker.text.ITextComponent.fromTranslation("e2ee.creature_resisted_morb",item.displayName);
+	    val message = capturable? fromTranslation("e2ee.creature_resisted_morb",item.displayName)
+		: fromTranslation("e2ee.creature_uncapturable");
 	    
 	    val x=projectile.position3f.x;
 	    val y=projectile.position3f.y;

--- a/scripts/do/throw_morb.zs
+++ b/scripts/do/throw_morb.zs
@@ -1,3 +1,15 @@
+/*
+
+Prevent some throwable stackable Entity Cells
+(like Thermal Expansion Morbs) from working, if
+mob not damaged
+
+Authors:
+https://github.com/git-confused
+https://github.com/Krutoy242
+
+*/
+
 import crafttweaker.entity.IEntityLivingBase;
 import crafttweaker.player.IPlayer;
 import crafttweaker.entity.IEntityDefinition;

--- a/scripts/do/throw_morb.zs
+++ b/scripts/do/throw_morb.zs
@@ -30,9 +30,7 @@ events.onProjectileImpactThrowable(function(e as crafttweaker.event.ProjectileIm
 	
 	val pokemon as crafttweaker.entity.IEntityLivingBase=e.rayTrace.entity;
 	    
-	if (pokemon.maxHealth==0||
-	    isNull(pokemon.definition)||
-	    isNull(pokemon.definition.name))return;
+	if pokemon.maxHealth==0 return;
 	    
 	val hpPortion=pokemon.health/pokemon.maxHealth;
 	if ( hpPortion > 0.3 && pokemon.health > 8){

--- a/scripts/do/throw_morb.zs
+++ b/scripts/do/throw_morb.zs
@@ -69,6 +69,7 @@ events.onProjectileImpactThrowable(function(e as crafttweaker.event.ProjectileIm
 		if(isNull(ii)||isNull(ii.id)){
 		    continue;
 		}
+		if(isNull(pokemon.definition)||isNull(pokemon.definition.id))return;//why does this happen?
 		if (pokemon.definition.id==ii.id){
 		    capturable=false;
 		    break;

--- a/scripts/do/throw_morb.zs
+++ b/scripts/do/throw_morb.zs
@@ -1,21 +1,16 @@
-import crafttweaker.events.IEventManager;
-import crafttweaker.event.ProjectileImpactThrowableEvent;
-import crafttweaker.event.IEventCancelable;
-import crafttweaker.event.IEntityEvent;
 import crafttweaker.entity.IEntityLivingBase;
 import crafttweaker.player.IPlayer;
-import crafttweaker.entity.IEntityItem;
-import crafttweaker.block.IBlockState;
-import crafttweaker.item.IItemStack;
 
 #loader crafttweaker reloadableevents
    
 events.onProjectileImpactThrowable(function(e as crafttweaker.event.ProjectileImpactThrowableEvent){
 	
 	if (isNull(e.thrower)||
-	    !(e.thrower instanceof crafttweaker.player.IPlayer)||
+	    !(e.thrower instanceof IPlayer)||
+	    e.thrower.world.remote||
 	    isNull(e.rayTrace.entity)||
-	    !(e.rayTrace.entity instanceof crafttweaker.entity.IEntityLivingBase)){return;}
+	    !(e.rayTrace.entity instanceof IEntityLivingBase)||
+	    e.rayTrace.entity instanceof crafttweaker.entity.IEntityAnimal) return;
 
 	val player as IPlayer = e.thrower;
 	if player.creative return;
@@ -28,8 +23,8 @@ events.onProjectileImpactThrowable(function(e as crafttweaker.event.ProjectileIm
 	    : null;
 	if isNull(item) return;
 	
-	val pokemon as crafttweaker.entity.IEntityLivingBase=e.rayTrace.entity;
-	    
+	val pokemon as IEntityLivingBase=e.rayTrace.entity;
+	
 	if pokemon.maxHealth==0 return;
 	    
 	val hpPortion=pokemon.health/pokemon.maxHealth;
@@ -48,10 +43,9 @@ events.onProjectileImpactThrowable(function(e as crafttweaker.event.ProjectileIm
 
 	    player.sendPlaySoundPacket("mekanism:etc.error", "ambient", pokemon.position, 2.0f, 1.5f);
 	    
-	    if(!player.world.remote){//always true but just in case
-		val itemEntity=item.createEntityItem(projectile.world,x,y,z);
-		projectile.world.spawnEntity(itemEntity);
-	    }
+	    val itemEntity=item.createEntityItem(projectile.world,x,y,z);
+	    projectile.world.spawnEntity(itemEntity);
+
 	    
 	    player.sendRichTextMessage(message);
 
@@ -60,4 +54,6 @@ events.onProjectileImpactThrowable(function(e as crafttweaker.event.ProjectileIm
 	}
 	
     });
+
+
 

--- a/scripts/do/throw_morb.zs
+++ b/scripts/do/throw_morb.zs
@@ -9,10 +9,7 @@ import crafttweaker.block.IBlockState;
 import crafttweaker.item.IItemStack;
 
 #loader crafttweaker reloadableevents
-
-//not handled: unthrowable unstackable pokeball items: <thaumadditions:dna_sample> <extrautils2:goldenlasso:*> 
-//not handled: already whitelisted to passive mobs: <randomthings:summoningpendulum>
-    
+   
 events.onProjectileImpactThrowable(function(e as crafttweaker.event.ProjectileImpactThrowableEvent){
 	
 	if (isNull(e.thrower)||
@@ -25,13 +22,13 @@ events.onProjectileImpactThrowable(function(e as crafttweaker.event.ProjectileIm
 	
 	val projectile=e.entity;
 	
-	//0 invalid, 1 morb, 2 reusable morb, 3 cyclic monster ball ...
-	val type=projectile.definition.id==<entity:thermalexpansion:morb>.id && projectile.nbt.EntityData.length==0 ? 1+projectile.nbt.Type
-	    : projectile.definition.id==<entity:cyclicmagic:magicnetempty>.id ? 3
-	    : 0;
-	if type==0 return;
+	val item=projectile.definition.id==<entity:thermalexpansion:morb>.id && projectile.nbt.EntityData.length==0 ?
+	    (projectile.nbt.Type==1 ? <thermalexpansion:morb:1> : <thermalexpansion:morb:0>)
+	    : projectile.definition.id==<entity:cyclicmagic:magicnetempty>.id ? <cyclicmagic:magic_net>
+	    : null;
+	if isNull(item) return;
 	
-	val pokemon as crafttweaker.entity.IEntityLivingBase=e.rayTrace.entity ;
+	val pokemon as crafttweaker.entity.IEntityLivingBase=e.rayTrace.entity;
 	    
 	if (pokemon.maxHealth==0||
 	    isNull(pokemon.definition)||
@@ -40,34 +37,22 @@ events.onProjectileImpactThrowable(function(e as crafttweaker.event.ProjectileIm
 	val hpPortion=pokemon.health/pokemon.maxHealth;
 	if ( hpPortion > 0.3 && pokemon.health > 8){
 	    
-
-
-	    val item=type==3?<cyclicmagic:magic_net>
-		:type==2?<thermalexpansion:morb:1>
-		:type==1?<thermalexpansion:morb>:null;
-
 	    //TODO find correct localized displayName for entity, not pokemon.definition.name
 	    val message = crafttweaker.text.ITextComponent.fromTranslation("e2ee.creature_resisted_morb",item.displayName);
-	    {
-		val x=projectile.x;
-		val y=projectile.y;
-		val z=projectile.z;
-
-		val pos_string=x~" "~y~" "~z;
+	    
+	    val x=projectile.position3f.x;
+	    val y=projectile.position3f.y;
+	    val z=projectile.position3f.z;
+	    
+	    val pos_string=x~" "~y~" "~z;
 		
-		server.commandManager.executeCommandSilent(pokemon, "/particle angryVillager "~pos_string~" 0.2 0.1 0.2 0.1 3 ");
+	    server.commandManager.executeCommandSilent(pokemon, "/particle angryVillager "~pos_string~" 0.2 0.1 0.2 0.1 3 ");
 
-		player.sendPlaySoundPacket("mekanism:etc.error", "ambient", pokemon.position, 2.0f, 1.5f);
-
-		if(!player.world.remote){
-		    
-		    val itemEntity=item.createEntityItem(projectile.world,
-					  projectile.position.x,
-					  projectile.position.y,
-					  projectile.position.z);
-		    projectile.world.spawnEntity(itemEntity);
-		}
-
+	    player.sendPlaySoundPacket("mekanism:etc.error", "ambient", pokemon.position, 2.0f, 1.5f);
+	    
+	    if(!player.world.remote){//always true but just in case
+		val itemEntity=item.createEntityItem(projectile.world,x,y,z);
+		projectile.world.spawnEntity(itemEntity);
 	    }
 	    
 	    player.sendRichTextMessage(message);
@@ -77,6 +62,4 @@ events.onProjectileImpactThrowable(function(e as crafttweaker.event.ProjectileIm
 	}
 	
     });
-
-
 

--- a/scripts/do/throw_morb.zs
+++ b/scripts/do/throw_morb.zs
@@ -18,104 +18,104 @@ import crafttweaker.text.ITextComponent.fromTranslation;
 #loader crafttweaker reloadableevents
 
 events.onProjectileImpactThrowable(function(e as crafttweaker.event.ProjectileImpactThrowableEvent){
-	
-	if (isNull(e.thrower)||
-	    !(e.thrower instanceof IPlayer)||
-	    e.thrower.world.remote||
-	    isNull(e.rayTrace.entity)||
-	    !(e.rayTrace.entity instanceof IEntityLivingBase)||
-	    e.rayTrace.entity instanceof crafttweaker.entity.IEntityAnimal) return;
+  
+  if (isNull(e.thrower)||
+      !(e.thrower instanceof IPlayer)||
+      e.thrower.world.remote||
+      isNull(e.rayTrace.entity)||
+      !(e.rayTrace.entity instanceof IEntityLivingBase)||
+      e.rayTrace.entity instanceof crafttweaker.entity.IEntityAnimal) return;
 
-	val player as IPlayer = e.thrower;
-	if player.creative return;
-	
-	val projectile=e.entity;
-	
-	val item=projectile.definition.id==<entity:thermalexpansion:morb>.id && projectile.nbt.EntityData.length==0 ?
-	    (projectile.nbt.Type==1 ? <thermalexpansion:morb:1> : <thermalexpansion:morb:0>)
-	    : projectile.definition.id==<entity:cyclicmagic:magicnetempty>.id ? <cyclicmagic:magic_net>
-	    : null;
-	if isNull(item) return;
-	
-	val pokemon as IEntityLivingBase=e.rayTrace.entity;
-	
-	if pokemon.maxHealth==0 return;
+  val player as IPlayer = e.thrower;
+  if player.creative return;
+  
+  val projectile=e.entity;
+  
+  val item=projectile.definition.id==<entity:thermalexpansion:morb>.id && projectile.nbt.EntityData.length==0 ?
+      (projectile.nbt.Type==1 ? <thermalexpansion:morb:1> : <thermalexpansion:morb:0>)
+      : projectile.definition.id==<entity:cyclicmagic:magicnetempty>.id ? <cyclicmagic:magic_net>
+      : null;
+  if isNull(item) return;
+  
+  val pokemon as IEntityLivingBase=e.rayTrace.entity;
+  
+  if pokemon.maxHealth==0 return;
 
-	val uncapturables=[<entity:iceandfire:cyclops>,
-			   <entity:iceandfire:deathwormegg>,
-			   <entity:iceandfire:dragonegg>,
-			   <entity:iceandfire:dragonskull>,
-			   <entity:iceandfire:firedragon>,
-			   <entity:iceandfire:gorgon>,
-			   <entity:iceandfire:hippogryphegg>,
-			   <entity:iceandfire:icedragon>,
-			   <entity:iceandfire:if_cockatriceegg>,
-			   <entity:iceandfire:if_mob_skull>,
-			   <entity:iceandfire:myrmex_egg>,
-			   <entity:iceandfire:myrmex_queen>,
-			   <entity:iceandfire:stonestatue>,
-			   <entity:iceandfire:tide_trident>,
-			   <entity:botania:doppleganger>,
-			   <entity:draconicevolution:guardiancrystal>,
-			   <entity:extrabotany:gaiaiii>,
-			   <entity:extrabotany:voidherrscher>,
-			   <entity:minecraft:ender_dragon>,
-			   <entity:minecraft:evocation_illager>,
-			   <entity:minecraft:vindication_illager>,
-			   <entity:minecraft:wither>,
-			   <entity:twilightforest:armored_giant>,
-			   <entity:twilightforest:armored_giant>,
-			   <entity:twilightforest:giant_miner>,
-			   <entity:twilightforest:giant_miner>,
-			   <entity:twilightforest:hydra>,
-			   <entity:twilightforest:knight_phantom>,
-			   <entity:twilightforest:lich>,
-			   <entity:twilightforest:minoshroom>,
-			   <entity:twilightforest:naga>,
-			   <entity:twilightforest:snow_queen>,
-			   <entity:twilightforest:ur_ghast>,
-			   <entity:twilightforest:yeti_alpha>] as IEntityDefinition[];
+  val uncapturables=[<entity:iceandfire:cyclops>,
+         <entity:iceandfire:deathwormegg>,
+         <entity:iceandfire:dragonegg>,
+         <entity:iceandfire:dragonskull>,
+         <entity:iceandfire:firedragon>,
+         <entity:iceandfire:gorgon>,
+         <entity:iceandfire:hippogryphegg>,
+         <entity:iceandfire:icedragon>,
+         <entity:iceandfire:if_cockatriceegg>,
+         <entity:iceandfire:if_mob_skull>,
+         <entity:iceandfire:myrmex_egg>,
+         <entity:iceandfire:myrmex_queen>,
+         <entity:iceandfire:stonestatue>,
+         <entity:iceandfire:tide_trident>,
+         <entity:botania:doppleganger>,
+         <entity:draconicevolution:guardiancrystal>,
+         <entity:extrabotany:gaiaiii>,
+         <entity:extrabotany:voidherrscher>,
+         <entity:minecraft:ender_dragon>,
+         <entity:minecraft:evocation_illager>,
+         <entity:minecraft:vindication_illager>,
+         <entity:minecraft:wither>,
+         <entity:twilightforest:armored_giant>,
+         <entity:twilightforest:armored_giant>,
+         <entity:twilightforest:giant_miner>,
+         <entity:twilightforest:giant_miner>,
+         <entity:twilightforest:hydra>,
+         <entity:twilightforest:knight_phantom>,
+         <entity:twilightforest:lich>,
+         <entity:twilightforest:minoshroom>,
+         <entity:twilightforest:naga>,
+         <entity:twilightforest:snow_queen>,
+         <entity:twilightforest:ur_ghast>,
+         <entity:twilightforest:yeti_alpha>] as IEntityDefinition[];
 
-	var capturable=true;
-	for ii in uncapturables {
-		if(isNull(ii)||isNull(ii.id)){
-		    continue;
-		}
-		if(isNull(pokemon.definition)||isNull(pokemon.definition.id))return;//why does this happen?
-		if (pokemon.definition.id==ii.id){
-		    capturable=false;
-		    break;
-		}
-	    }
+  var capturable=true;
+  for ii in uncapturables {
+    if(isNull(ii)||isNull(ii.id)){
+        continue;
+    }
+    if(isNull(pokemon.definition)||isNull(pokemon.definition.id))return;//why does this happen?
+    if (pokemon.definition.id==ii.id){
+        capturable=false;
+        break;
+    }
+      }
 
-	
-	val hpPortion=pokemon.health/pokemon.maxHealth;
-	if ( !capturable || (hpPortion > 0.3 && pokemon.health > 8) ){
-	    
-	    //TODO find correct localized displayName for entity, not pokemon.definition.name
-	    val message = capturable? fromTranslation("e2ee.creature_resisted_morb",item.displayName)
-		: fromTranslation("e2ee.creature_uncapturable");
-	    
-	    val x=projectile.position3f.x;
-	    val y=projectile.position3f.y;
-	    val z=projectile.position3f.z;
-	    
-	    val pos_string=x~" "~y~" "~z;
-		
-	    server.commandManager.executeCommandSilent(pokemon, "/particle angryVillager "~pos_string~" 0.2 0.1 0.2 0.1 3 ");
+  
+  val hpPortion=pokemon.health/pokemon.maxHealth;
+  if ( !capturable || (hpPortion > 0.3 && pokemon.health > 8) ){
+      
+      //TODO find correct localized displayName for entity, not pokemon.definition.name
+      val message = capturable? fromTranslation("e2ee.creature_resisted_morb",item.displayName)
+    : fromTranslation("e2ee.creature_uncapturable");
+      
+      val x=projectile.position3f.x;
+      val y=projectile.position3f.y;
+      val z=projectile.position3f.z;
+      
+      val pos_string=x~" "~y~" "~z;
+    
+      server.commandManager.executeCommandSilent(pokemon, "/particle angryVillager "~pos_string~" 0.2 0.1 0.2 0.1 3 ");
 
-	    player.sendPlaySoundPacket("mekanism:etc.error", "ambient", pokemon.position, 2.0f, 1.5f);
-	    
-	    val itemEntity=item.createEntityItem(projectile.world,x,y,z);
-	    projectile.world.spawnEntity(itemEntity);
+      player.sendPlaySoundPacket("mekanism:etc.error", "ambient", pokemon.position, 2.0f, 1.5f);
+      
+      val itemEntity=item.createEntityItem(projectile.world,x,y,z);
+      projectile.world.spawnEntity(itemEntity);
 
-	    
-	    player.sendRichTextMessage(message);
+      
+      player.sendRichTextMessage(message);
 
-	    e.cancel();
-	    projectile.setDead();
-	}
-	
+      e.cancel();
+      projectile.setDead();
+  }
+  
     });
 
 

--- a/scripts/do/throw_morb.zs
+++ b/scripts/do/throw_morb.zs
@@ -17,8 +17,8 @@ import crafttweaker.text.ITextComponent.fromTranslation;
 
 #loader crafttweaker reloadableevents
 
-static hpPortionTreshold as double = 0.3;
-static ignoredHealth as double = 8.0;
+static hpPortionTreshold as double = 0.8;
+static ignoredHealth as double = 20.0;
 
 // morb-like items limitation hint
 scripts.category.tooltip_utils.desc.both(<thermalexpansion:morb:*>, "morb_resist", hpPortionTreshold * 100, ignoredHealth / 2);

--- a/scripts/do/throw_morb.zs
+++ b/scripts/do/throw_morb.zs
@@ -1,0 +1,82 @@
+import crafttweaker.events.IEventManager;
+import crafttweaker.event.ProjectileImpactThrowableEvent;
+import crafttweaker.event.IEventCancelable;
+import crafttweaker.event.IEntityEvent;
+import crafttweaker.entity.IEntityLivingBase;
+import crafttweaker.player.IPlayer;
+import crafttweaker.entity.IEntityItem;
+import crafttweaker.block.IBlockState;
+import crafttweaker.item.IItemStack;
+
+#loader crafttweaker reloadableevents
+
+//not handled: unthrowable unstackable pokeball items: <thaumadditions:dna_sample> <extrautils2:goldenlasso:*> 
+//not handled: already whitelisted to passive mobs: <randomthings:summoningpendulum>
+    
+events.onProjectileImpactThrowable(function(e as crafttweaker.event.ProjectileImpactThrowableEvent){
+	
+	if (isNull(e.thrower)||
+	    !(e.thrower instanceof crafttweaker.player.IPlayer)||
+	    isNull(e.rayTrace.entity)||
+	    !(e.rayTrace.entity instanceof crafttweaker.entity.IEntityLivingBase)){return;}
+
+	val player as IPlayer = e.thrower;
+	if player.creative return;
+	
+	val projectile=e.entity;
+	
+	//0 invalid, 1 morb, 2 reusable morb, 3 cyclic monster ball ...
+	val type=projectile.definition.id==<entity:thermalexpansion:morb>.id && projectile.nbt.EntityData.length==0 ? 1+projectile.nbt.Type
+	    : projectile.definition.id==<entity:cyclicmagic:magicnetempty>.id ? 3
+	    : 0;
+	if type==0 return;
+	
+	val pokemon as crafttweaker.entity.IEntityLivingBase=e.rayTrace.entity ;
+	    
+	if (pokemon.maxHealth==0||
+	    isNull(pokemon.definition)||
+	    isNull(pokemon.definition.name))return;
+	    
+	val hpPortion=pokemon.health/pokemon.maxHealth;
+	if ( hpPortion > 0.3 && pokemon.health > 8){
+	    
+
+
+	    val item=type==3?<cyclicmagic:magic_net>
+		:type==2?<thermalexpansion:morb:1>
+		:type==1?<thermalexpansion:morb>:null;
+
+	    //TODO find correct localized displayName for entity, not pokemon.definition.name
+	    val message = crafttweaker.text.ITextComponent.fromTranslation("e2ee.creature_resisted_morb",item.displayName);
+	    {
+		val x=projectile.x;
+		val y=projectile.y;
+		val z=projectile.z;
+
+		val pos_string=x~" "~y~" "~z;
+		
+		server.commandManager.executeCommandSilent(pokemon, "/particle angryVillager "~pos_string~" 0.2 0.1 0.2 0.1 3 ");
+
+		player.sendPlaySoundPacket("mekanism:etc.error", "ambient", pokemon.position, 2.0f, 1.5f);
+
+		if(!player.world.remote){
+		    
+		    val itemEntity=item.createEntityItem(projectile.world,
+					  projectile.position.x,
+					  projectile.position.y,
+					  projectile.position.z);
+		    projectile.world.spawnEntity(itemEntity);
+		}
+
+	    }
+	    
+	    player.sendRichTextMessage(message);
+
+	    e.cancel();
+	    projectile.setDead();
+	}
+	
+    });
+
+
+

--- a/scripts/do/throw_morb.zs
+++ b/scripts/do/throw_morb.zs
@@ -17,106 +17,101 @@ import crafttweaker.text.ITextComponent.fromTranslation;
 
 #loader crafttweaker reloadableevents
 
-events.onProjectileImpactThrowable(function(e as crafttweaker.event.ProjectileImpactThrowableEvent){
-  
-  if (isNull(e.thrower)||
-      !(e.thrower instanceof IPlayer)||
-      e.thrower.world.remote||
-      isNull(e.rayTrace.entity)||
-      !(e.rayTrace.entity instanceof IEntityLivingBase)||
-      e.rayTrace.entity instanceof crafttweaker.entity.IEntityAnimal) return;
+events.onProjectileImpactThrowable(function (e as crafttweaker.event.ProjectileImpactThrowableEvent) {
+  if (isNull(e.thrower)
+      || !(e.thrower instanceof IPlayer)
+      || e.thrower.world.remote
+      || isNull(e.rayTrace.entity)
+      || !(e.rayTrace.entity instanceof IEntityLivingBase)
+      || e.rayTrace.entity instanceof crafttweaker.entity.IEntityAnimal
+  ) return;
 
   val player as IPlayer = e.thrower;
-  if player.creative return;
-  
-  val projectile=e.entity;
-  
-  val item=projectile.definition.id==<entity:thermalexpansion:morb>.id && projectile.nbt.EntityData.length==0 ?
-      (projectile.nbt.Type==1 ? <thermalexpansion:morb:1> : <thermalexpansion:morb:0>)
-      : projectile.definition.id==<entity:cyclicmagic:magicnetempty>.id ? <cyclicmagic:magic_net>
+  if (player.creative) return;
+
+  val projectile = e.entity;
+
+  val item = projectile.definition.id == <entity:thermalexpansion:morb>.id && projectile.nbt.EntityData.length == 0
+    ? (projectile.nbt.Type == 1 ? <thermalexpansion:morb:1> : <thermalexpansion:morb:0>)
+    : projectile.definition.id == <entity:cyclicmagic:magicnetempty>.id
+      ? <cyclicmagic:magic_net>
       : null;
-  if isNull(item) return;
-  
-  val pokemon as IEntityLivingBase=e.rayTrace.entity;
-  
-  if pokemon.maxHealth==0 return;
+  if (isNull(item)) return;
 
-  val uncapturables=[<entity:iceandfire:cyclops>,
-         <entity:iceandfire:deathwormegg>,
-         <entity:iceandfire:dragonegg>,
-         <entity:iceandfire:dragonskull>,
-         <entity:iceandfire:firedragon>,
-         <entity:iceandfire:gorgon>,
-         <entity:iceandfire:hippogryphegg>,
-         <entity:iceandfire:icedragon>,
-         <entity:iceandfire:if_cockatriceegg>,
-         <entity:iceandfire:if_mob_skull>,
-         <entity:iceandfire:myrmex_egg>,
-         <entity:iceandfire:myrmex_queen>,
-         <entity:iceandfire:stonestatue>,
-         <entity:iceandfire:tide_trident>,
-         <entity:botania:doppleganger>,
-         <entity:draconicevolution:guardiancrystal>,
-         <entity:extrabotany:gaiaiii>,
-         <entity:extrabotany:voidherrscher>,
-         <entity:minecraft:ender_dragon>,
-         <entity:minecraft:evocation_illager>,
-         <entity:minecraft:vindication_illager>,
-         <entity:minecraft:wither>,
-         <entity:twilightforest:armored_giant>,
-         <entity:twilightforest:armored_giant>,
-         <entity:twilightforest:giant_miner>,
-         <entity:twilightforest:giant_miner>,
-         <entity:twilightforest:hydra>,
-         <entity:twilightforest:knight_phantom>,
-         <entity:twilightforest:lich>,
-         <entity:twilightforest:minoshroom>,
-         <entity:twilightforest:naga>,
-         <entity:twilightforest:snow_queen>,
-         <entity:twilightforest:ur_ghast>,
-         <entity:twilightforest:yeti_alpha>] as IEntityDefinition[];
+  val pokemon as IEntityLivingBase = e.rayTrace.entity;
 
-  var capturable=true;
+  if (pokemon.maxHealth == 0) return;
+
+  val uncapturables = [
+    <entity:iceandfire:cyclops>,
+    <entity:iceandfire:deathwormegg>,
+    <entity:iceandfire:dragonegg>,
+    <entity:iceandfire:dragonskull>,
+    <entity:iceandfire:firedragon>,
+    <entity:iceandfire:gorgon>,
+    <entity:iceandfire:hippogryphegg>,
+    <entity:iceandfire:icedragon>,
+    <entity:iceandfire:if_cockatriceegg>,
+    <entity:iceandfire:if_mob_skull>,
+    <entity:iceandfire:myrmex_egg>,
+    <entity:iceandfire:myrmex_queen>,
+    <entity:iceandfire:stonestatue>,
+    <entity:iceandfire:tide_trident>,
+    <entity:botania:doppleganger>,
+    <entity:draconicevolution:guardiancrystal>,
+    <entity:extrabotany:gaiaiii>,
+    <entity:extrabotany:voidherrscher>,
+    <entity:minecraft:ender_dragon>,
+    <entity:minecraft:evocation_illager>,
+    <entity:minecraft:vindication_illager>,
+    <entity:minecraft:wither>,
+    <entity:twilightforest:armored_giant>,
+    <entity:twilightforest:armored_giant>,
+    <entity:twilightforest:giant_miner>,
+    <entity:twilightforest:giant_miner>,
+    <entity:twilightforest:hydra>,
+    <entity:twilightforest:knight_phantom>,
+    <entity:twilightforest:lich>,
+    <entity:twilightforest:minoshroom>,
+    <entity:twilightforest:naga>,
+    <entity:twilightforest:snow_queen>,
+    <entity:twilightforest:ur_ghast>,
+    <entity:twilightforest:yeti_alpha>
+  ] as IEntityDefinition[];
+
+  var capturable = true;
   for ii in uncapturables {
-    if(isNull(ii)||isNull(ii.id)){
-        continue;
+    if (isNull(ii) || isNull(ii.id)) {
+      continue;
     }
-    if(isNull(pokemon.definition)||isNull(pokemon.definition.id))return;//why does this happen?
-    if (pokemon.definition.id==ii.id){
-        capturable=false;
-        break;
+    if (isNull(pokemon.definition) || isNull(pokemon.definition.id)) return;// why does this happen?
+    if (pokemon.definition.id == ii.id) {
+      capturable = false;
+      break;
     }
-      }
-
-  
-  val hpPortion=pokemon.health/pokemon.maxHealth;
-  if ( !capturable || (hpPortion > 0.3 && pokemon.health > 8) ){
-      
-      //TODO find correct localized displayName for entity, not pokemon.definition.name
-      val message = capturable? fromTranslation("e2ee.creature_resisted_morb",item.displayName)
-    : fromTranslation("e2ee.creature_uncapturable");
-      
-      val x=projectile.position3f.x;
-      val y=projectile.position3f.y;
-      val z=projectile.position3f.z;
-      
-      val pos_string=x~" "~y~" "~z;
-    
-      server.commandManager.executeCommandSilent(pokemon, "/particle angryVillager "~pos_string~" 0.2 0.1 0.2 0.1 3 ");
-
-      player.sendPlaySoundPacket("mekanism:etc.error", "ambient", pokemon.position, 2.0f, 1.5f);
-      
-      val itemEntity=item.createEntityItem(projectile.world,x,y,z);
-      projectile.world.spawnEntity(itemEntity);
-
-      
-      player.sendRichTextMessage(message);
-
-      e.cancel();
-      projectile.setDead();
   }
-  
-    });
 
+  val hpPortion = pokemon.health / pokemon.maxHealth;
+  if (!capturable || (hpPortion > 0.3 && pokemon.health > 8)) {
+    // TODO find correct localized displayName for entity, not pokemon.definition.name
+    val message = capturable
+      ? fromTranslation('e2ee.creature_resisted_morb', item.displayName)
+      : fromTranslation('e2ee.creature_uncapturable');
 
+    val x = projectile.position3f.x;
+    val y = projectile.position3f.y;
+    val z = projectile.position3f.z;
 
+    server.commandManager.executeCommandSilent(pokemon, '/particle angryVillager ' ~ x ~ ' ' ~ y ~ ' ' ~ z ~ ' 0.2 0.1 0.2 0.1 3 ');
+
+    player.sendPlaySoundPacket('mekanism:etc.error', 'ambient', pokemon.position, 2.0f, 1.5f);
+
+    val itemEntity = item.createEntityItem(projectile.world, x, y, z);
+    projectile.world.spawnEntity(itemEntity);
+
+    player.sendRichTextMessage(message);
+
+    e.cancel();
+    projectile.setDead();
+  }
+});


### PR DESCRIPTION
The affected items can no longer rapidly neutralize hordes of enemies at range.
For the item to be effective, the target must be below 30% hearts or have fewer than 4 hearts total.

Affects morb, reusable morb, monster ball.

Does not affect thaumadditions entity cell. It's not stackable or throwable, so maybe this can be left alone.

The cursed lasso already has this limitation.

The summoning pendulum only works on non hostiles.

Please list any items I missed, if you think they need a similar treatment.


Things tested:

sound plays when item fails
particles appear when item fails
sound and particles work in other dims too
thrown item which failed to activate drops on ground (it is not destroyed)
the correct item drops on the ground
does not affect creative mode
jei tooltip on affected items
thrown items which already have a stored monster are not affected
dropped items aren't duplicated (except in creative, as usual)

Not tested:

anything multiplayer
