### PR TITLE
Thaumcraft aspect integration for magic mods

### DIFF
--- a/config/tcresearchpatcher/entries/alchemy_entiers.json
+++ b/config/tcresearchpatcher/entries/alchemy_entiers.json
@@ -9,7 +9,7 @@
             "stages": [
                 {
                     "text": "research_stage.thaumadditions:essence_salt.1", 
-                    "required_knowledge":["OBSERVATION;THAUMADDITIONS;1"]
+                    "required_knowledge":["OBSERVATION;BASICS;1"]
                 },
                 {
                     "text": "research_stage.thaumadditions:essence_salt.2",
@@ -84,7 +84,7 @@
             "stages": [
                 {
                     "text": "research_stage.thaumadditions:flux_concentrator.1",
-                    "required_knowledge":["THEORY;ALCHEMY;1","THEORY;THAUMADDITIONS;1"],
+                    "required_knowledge":["THEORY;ALCHEMY;1"],
                     "required_item":["thaumcraft:vishroom"]
                 },
                 {
@@ -103,7 +103,7 @@
             "stages": [
                 {
                     "text": "research_stage.thaumadditions:brass_jar.1",
-                    "required_knowledge":["OBSERVATION;ALCHEMY;1","OBSERVATION;THAUMADDITIONS;1"],
+                    "required_knowledge":["OBSERVATION;ALCHEMY;1"],
                     "required_craft":["thaumcraft:ingot;1;2"]
                 },
                 {
@@ -122,7 +122,7 @@
             "stages": [
                 {
                     "text": "research_stage.thaumadditions:thaumium_jar.1",
-                    "required_knowledge":["OBSERVATION;ALCHEMY;1","OBSERVATION;THAUMADDITIONS;1"],
+                    "required_knowledge":["OBSERVATION;ALCHEMY;1"],
                     "required_craft":["thaumcraft:ingot;1"]
                 },
                 {
@@ -141,7 +141,7 @@
             "stages": [
                 {
                     "text": "research_stage.thaumadditions:eldritch_jar.1",
-                    "required_knowledge":["OBSERVATION;ALCHEMY;1","OBSERVATION;THAUMADDITIONS;1"],
+                    "required_knowledge":["OBSERVATION;ALCHEMY;1"],
                     "required_craft":["thaumcraft:ingot;1;1"]
                 },
                 {
@@ -160,7 +160,7 @@
             "stages": [
                 {
                     "text": "research_stage.thaumadditions:mithrillium_jar.1",
-                    "required_knowledge":["OBSERVATION;ALCHEMY;1","OBSERVATION;THAUMADDITIONS;1"]
+                    "required_knowledge":["OBSERVATION;ALCHEMY;1"]
                 },
                 {
                     "text": "research_stage.thaumadditions:mithrillium_jar.2",
@@ -178,7 +178,7 @@
             "stages": [
                 {
                     "text": "research_stage.thaumadditions:adaminite_jar.1",
-                    "required_knowledge":["OBSERVATION;ALCHEMY;1","OBSERVATION;THAUMADDITIONS;1"]
+                    "required_knowledge":["OBSERVATION;ALCHEMY;1"]
                 },
                 {
                     "text": "research_stage.thaumadditions:adaminite_jar.3",
@@ -196,7 +196,7 @@
             "stages": [
                 {
                     "text": "research_stage.thaumadditions:mithminite_jar.1",
-                    "required_knowledge":["OBSERVATION;ALCHEMY;1","OBSERVATION;THAUMADDITIONS;1"]
+                    "required_knowledge":["OBSERVATION;ALCHEMY;1"]
                 },
                 {
                     "text": "research_stage.thaumadditions:mithminite_jar.2",
@@ -214,7 +214,7 @@
             "stages": [
                 {
                     "text": "research_stage.thaumadditions:mithrillium_smelter.1",
-                    "required_knowledge":["THEORY;ALCHEMY;1","THEORY;THAUMADDITIONS;1"]
+                    "required_knowledge":["THEORY;ALCHEMY;1"]
                 },
                 {
                     "text": "research_stage.thaumadditions:mithrillium_smelter.2",
@@ -232,7 +232,7 @@
             "stages": [
                 {
                     "text": "research_stage.thaumadditions:adaminite_smelter.1",
-                    "required_knowledge":["THEORY;ALCHEMY;1","THEORY;THAUMADDITIONS;1"]
+                    "required_knowledge":["THEORY;ALCHEMY;1"]
                 },
                 {
                     "text": "research_stage.thaumadditions:adaminite_smelter.2",
@@ -250,7 +250,7 @@
             "stages": [
                 {
                     "text": "research_stage.thaumadditions:mithminite_smelter.1",
-                    "required_knowledge":["THEORY;ALCHEMY;1","THEORY;THAUMADDITIONS;1"]
+                    "required_knowledge":["THEORY;ALCHEMY;1"]
                 },
                 {
                     "text": "research_stage.thaumadditions:mithminite_smelter.2",

--- a/config/tcresearchpatcher/entries/artifice_entires.json
+++ b/config/tcresearchpatcher/entries/artifice_entires.json
@@ -10,7 +10,7 @@
             "stages": [
                 {
                     "text": "research_stage.thaumadditions:arcane_cake.1", 
-                    "required_knowledge":["OBSERVATION;THAUMADDITIONS;1"],
+                    "required_knowledge":["OBSERVATION;ARTIFICE;1"],
                     "required_item":["minecraft:cake"]
                 },
                 {
@@ -28,7 +28,7 @@
             "stages": [
                 {
                     "text": "research_stage.thaumadditions:aura_disperser.1",
-                    "required_knowledge":["OBSERVATION;THAUMADDITIONS;1","THEORY;ARTIFICE;1"],
+                    "required_knowledge":["THEORY;ARTIFICE;1"],
                     "required_item":["thaumadditions:salt_essence"]
                 },
                 {
@@ -64,7 +64,7 @@
             "stages": [
                 {
                     "text": "research_stage.thaumadditions:seal.1",
-                    "required_knowledge":["OBSERVATION;THAUMADDITIONS;1"],
+                    "required_knowledge":["OBSERVATION;ARTIFICE;1"],
                     "required_item":["minecraft:gold_ingot;1","minecraft:wool;1;0"]
                 },
                 {
@@ -137,7 +137,7 @@
             "stages": [
                 {
                     "text": "research_stage.thaumadditions:crystal_lamp.1",
-                    "required_knowledge":["THEORY;ARTIFICE;1","THEORY;THAUMADDITIONS;1"],
+                    "required_knowledge":["THEORY;ARTIFICE;1"],
                     "require_item":["thaumcraft:plank_greatwood","thaumcraft:crystal_essence;1;{Aspects: [{amount: 1, key: 'lux'}]}"]
                 },
                 {
@@ -156,7 +156,7 @@
             "stages": [
                 {
                     "text": "research_stage.thaumadditions:seal_globe.1",
-                    "required_knowledge":["THEORY;ARTIFICE;1","THEORY;THAUMADDITIONS;1"],
+                    "required_knowledge":["THEORY;ARTIFICE;1"],
                     "require_craft":["thaumcraft:seal"]
                 },
                 {

--- a/config/tcresearchpatcher/entries/eldritch_entries.json
+++ b/config/tcresearchpatcher/entries/eldritch_entries.json
@@ -10,7 +10,7 @@
             "stages": [
                 {
                     "text": "research_stage.thaumadditions:void_elemental_pickaxe.1", 
-                    "required_knowledge":["THEORY;THAUMADDITIONS;1","THEORY;ELDRITCH;1"],
+                    "required_knowledge":["OBSERVATION;ELDRITCH;1","THEORY;ELDRITCH;1"],
                     "warp": 2
                 },
                 {
@@ -29,7 +29,7 @@
             "stages": [
                 {
                     "text": "research_stage.thaumadditions:void_elemental_axe.1", 
-                    "required_knowledge":["THEORY;THAUMADDITIONS;1","THEORY;ELDRITCH;1"],
+                    "required_knowledge":["OBSERVATION;ELDRITCH;1","THEORY;ELDRITCH;1"],
                     "warp":2
                 },
                 {
@@ -48,7 +48,7 @@
             "stages": [
                 {
                     "text": "research_stage.thaumadditions:void_elemental_shovel.1", 
-                    "required_knowledge":["THEORY;THAUMADDITIONS;1","THEORY;ELDRITCH;1"],
+                    "required_knowledge":["OBSERVATION;ELDRITCH;1","THEORY;ELDRITCH;1"],
                     "warp":2
                 },
                 {
@@ -67,7 +67,7 @@
             "stages": [
                 {
                     "text": "research_stage.thaumadditions:void_elemental_hoe.1", 
-                    "required_knowledge":["THEORY;THAUMADDITIONS;1","THEORY;ELDRITCH;1"],
+                    "required_knowledge":["OBSERVATION;ELDRITCH;1","THEORY;ELDRITCH;1"],
                     "warp":2
                 },
                 {
@@ -85,7 +85,7 @@
             "stages": [
                 {
                     "text": "research_stage.thaumadditions:void_thaumometer.1", 
-                    "required_knowledge":["THEORY;THAUMADDITIONS;1","THEORY;ELDRITCH;1"],
+                    "required_knowledge":["OBSERVATION;ELDRITCH;1","THEORY;ELDRITCH;1"],
                     "warp":1
                 },
                 {
@@ -103,7 +103,7 @@
             "stages": [
                 {
                     "text": "research_stage.thaumadditions:void_crop.1", 
-                    "required_knowledge":["THEORY;THAUMADDITIONS;1","THEORY;ELDRITCH;1"],
+                    "required_knowledge":["OBSERVATION;ELDRITCH;1","THEORY;ELDRITCH;1"],
                     "required_item":["thaumcraft:void_seed;13"],
                     "warp":4
                 },
@@ -122,7 +122,7 @@
             "stages": [
                 {
                     "text": "research_stage.thaumadditions:void_anvil.1", 
-                    "required_knowledge":["THEORY;THAUMADDITIONS;1","THEORY;ELDRITCH;1"],
+                    "required_knowledge":["OBSERVATION;ELDRITCH;1","THEORY;ELDRITCH;1"],
                     "required_craft":["cyclicmagic:block_anvil_magma"],
                     "warp":3
                 },
@@ -142,7 +142,7 @@
             "stages": [
                 {
                     "text": "research_stage.thaumadditions:wormhole_mirror.1", 
-                    "required_knowledge":["THEORY;THAUMADDITIONS;1","THEORY;ELDRITCH;1"],
+                    "required_knowledge":["OBSERVATION;ELDRITCH;1","THEORY;ELDRITCH;1"],
                     "required_craft":["thaumcraft:mirrored_glass"],
                     "warp":2
                 },
@@ -162,7 +162,7 @@
             "stages": [
                 {
                     "text": "research_stage.thaumadditions:mithrillium.1", 
-                    "required_knowledge":["THEORY;THAUMADDITIONS;2","THEORY;ELDRITCH;2"]
+                    "required_knowledge":["OBSERVATION;ELDRITCH;2","THEORY;ELDRITCH;2"]
                 },
                 {
                     "text": "research_stage.thaumadditions:mithrillium.2",
@@ -180,7 +180,7 @@
             "stages": [
                 {
                     "text": "research_stage.thaumadditions:adaminite.1", 
-                    "required_knowledge":["THEORY;THAUMADDITIONS;3","THEORY;ELDRITCH;3"],
+                    "required_knowledge":["OBSERVATION;ELDRITCH;3","THEORY;ELDRITCH;3"],
                     "warp":5
                 },
                 {
@@ -199,7 +199,7 @@
             "stages": [
                 {
                     "text": "research_stage.thaumadditions:mithminite.1", 
-                    "required_knowledge":["THEORY;THAUMADDITIONS;4","THEORY;ELDRITCH;4"],
+                    "required_knowledge":["OBSERVATION;ELDRITCH;4","THEORY;ELDRITCH;4"],
                     "warp":10
                 },
                 {
@@ -236,7 +236,7 @@
             "stages": [
                 {
                     "text": "research_stage.thaumadditions:shadow_beam_staff.1", 
-                    "required_knowledge":["THEORY;THAUMADDITIONS;1","OBSERVATION;THAYMADDITIONS;2"]
+                    "required_knowledge":["OBSERVATION;ELDRITCH;1","OBSERVATION;ELDRITCH;2"]
                 },
                 {
                     "text": "research_stage.thaumadditions:shadow_beam_staff.2",
@@ -308,7 +308,7 @@
             "stages": [
                 {
                     "text": "research_stage.thaumadditions:mithminite_scythe.1", 
-                    "required_knowledge":["THEORY;THAUMADDITIONS;2","OBSERVATION;THAYMADDITIONS;2"]
+                    "required_knowledge":["OBSERVATION;ELDRITCH;2","OBSERVATION;ELDRITCH;2"]
                 },
                 {
                     "text": "research_stage.thaumadditions:mithminite_scythe.2",
@@ -344,7 +344,7 @@
             "stages": [
                 {
                     "text": "research_stage.thaumadditions:mithminite_hood.1", 
-                    "required_knowledge":["THEORY;THAUMADDITIONS;2","THEORY;ELDRITCH;2"]
+                    "required_knowledge":["OBSERVATION;ELDRITCH;2","THEORY;ELDRITCH;2"]
                 },
                 {
                     "text": "research_stage.thaumadditions:mithminite_hood.2",
@@ -362,7 +362,7 @@
             "stages": [
                 {
                     "text": "research_stage.thaumadditions:mithminite_robe.1", 
-                    "required_knowledge":["THEORY;THAUMADDITIONS;2","THEORY;ELDRITCH;2"]
+                    "required_knowledge":["OBSERVATION;ELDRITCH;2","THEORY;ELDRITCH;2"]
                 },
                 {
                     "text": "research_stage.thaumadditions:mithminite_robe.2",
@@ -380,7 +380,7 @@
             "stages": [
                 {
                     "text": "research_stage.thaumadditions:mithminite_belt.1", 
-                    "required_knowledge":["THEORY;THAUMADDITIONS;2","THEORY;ELDRITCH;2"]
+                    "required_knowledge":["OBSERVATION;ELDRITCH;2","THEORY;ELDRITCH;2"]
                 },
                 {
                     "text": "research_stage.thaumadditions:mithminite_belt.2",
@@ -398,7 +398,7 @@
             "stages": [
                 {
                     "text": "research_stage.thaumadditions:mithminite_boots.1", 
-                    "required_knowledge":["THEORY;THAUMADDITIONS;2","THEORY;ELDRITCH;2"]
+                    "required_knowledge":["OBSERVATION;ELDRITCH;2","THEORY;ELDRITCH;2"]
                 },
                 {
                     "text": "research_stage.thaumadditions:mithminite_boots.2",
@@ -416,7 +416,7 @@
             "stages": [
                 {
                     "text": "research_stage.thaumadditions:aspect_combiner.1", 
-                    "required_knowledge":["THEORY;THAUMADDITIONS;2","THEORY;ELDRITCH;2"]
+                    "required_knowledge":["OBSERVATION;ELDRITCH;2","THEORY;ELDRITCH;2"]
                 },
                 {
                     "text": "research_stage.thaumadditions:aspect_combiner.2",
@@ -434,7 +434,7 @@
             "stages": [
                 {
                     "text": "research_stage.thaumadditions:aura_charger.1", 
-                    "required_knowledge":["THEORY;THAUMADDITIONS;2","THEORY;ELDRITCH;2"]
+                    "required_knowledge":["OBSERVATION;ELDRITCH;2","THEORY;ELDRITCH;2"]
                 },
                 {
                     "text": "research_stage.thaumadditions:aura_charger.2",

--- a/config/tcresearchpatcher/patches/manual_changes.json
+++ b/config/tcresearchpatcher/patches/manual_changes.json
@@ -230,4 +230,10 @@
    "path":"stages/1/recipes",
    "value":["thaumcraft:primal_metal"]}
  ]}
+
+ ,{"key":"TT_ENERGETIC_NITOR","ops":[
+  {"op":"replace",
+  "path":"stages/1/recipes",
+  "value":["thaumcraft:energetic_nitor"]}
+]}
 ]

--- a/scripts/mods/bloodmagic.zs
+++ b/scripts/mods/bloodmagic.zs
@@ -257,16 +257,6 @@ for item in alcTableOres {
 # [Blood Wood] from [Spectre Wood]*2
 mods.bloodmagic.BloodAltar.addRecipe(<animus:blockbloodwood>, <randomthings:spectrelog>, 0, 2000, 12, 12);
 
-# "I dont want to kill anyone" mode
-# [Weak Blood Shard] from [Phial of Aversio Essentia][+1]
-mods.thaumcraft.Crucible.registerRecipe(
-  "blood_shard", # Name
-  "BASEALCHEMY", # Research
-  <bloodmagic:blood_shard>, # Output
-  <ore:nuggetAdaminite>, # Input
-  [<aspect:aversio> * 10]
-);
-
 # [Crystal Cluster]*64 from [Benitoite][+3]
 # mods.bloodmagic.AlchemyTable.addRecipe(IItemStack output, IItemStack[] inputs, int syphon, int ticks, int minTier);
 mods.bloodmagic.AlchemyTable.addRecipe(<bloodmagic:decorative_brick:2> * 64, [

--- a/scripts/mods/bloodmagic.zs
+++ b/scripts/mods/bloodmagic.zs
@@ -270,3 +270,6 @@ mods.bloodmagic.AlchemyTable.addRecipe(<bloodmagic:decorative_brick:2> * 64, [
 craft.shapeless(<bloodmagic:decorative_brick:3> * 4, "****", {
   "*": <bloodmagic:decorative_brick:2>, # Crystal Cluster
 });
+
+# [Sigil of the whirlwind]
+mods.bloodmagic.AlchemyArray.addRecipe(<bloodmagic:sigil_whirlwind>, <minecraft:shield>, <bloodmagic:slate>);

--- a/scripts/mods/thaumadditions.zs
+++ b/scripts/mods/thaumadditions.zs
@@ -20,7 +20,7 @@ mods.thaumcraft.Infusion.removeRecipe(<thaumadditions:crystal_crusher>);
 mods.thaumcraft.ArcaneWorkbench.registerShapedRecipe("crystal_crusher", 
 "CRYSTALCRUSHER", 
 50,
-[<aspect:perditio>*6,<aspect:terra>*3], 
+[<aspect:perditio>*6, <aspect:terra>*3], 
 <thaumadditions:crystal_crusher>, 
   Grid(["pretty",
   "S S S",
@@ -54,7 +54,7 @@ mods.thaumcraft.Infusion.removeRecipe(<thaumadditions:void_thaumometer>);
 mods.thaumcraft.ArcaneWorkbench.registerShapedRecipe("void_thaumometer", 
 "VOIDTHAUMOMETER", 
 100,
-[<aspect:aer>,<aspect:ignis>,<aspect:aqua>,<aspect:terra>,<aspect:ordo>,<aspect:perditio>], 
+[<aspect:aer>, <aspect:ignis>, <aspect:aqua>, <aspect:terra>, <aspect:ordo>, <aspect:perditio>], 
 <thaumadditions:void_thaumometer>, 
   Grid(["pretty",
   "  V  ",
@@ -69,7 +69,7 @@ mods.thaumcraft.ArcaneWorkbench.removeRecipe(<thaumadditions:vis_scribing_tools>
 mods.thaumcraft.ArcaneWorkbench.registerShapedRecipe("vis_scribing_tools", 
 "VISSCRIBINGTOOLS", 
 100,
-[<aspect:aer>,<aspect:ignis>,<aspect:aqua>,<aspect:terra>,<aspect:ordo>,<aspect:perditio>], 
+[<aspect:aer>, <aspect:ignis>, <aspect:aqua>, <aspect:terra>, <aspect:ordo>, <aspect:perditio>], 
 <thaumadditions:vis_scribing_tools>, 
   Grid(["pretty",
   "  P  ",
@@ -101,7 +101,7 @@ mods.thaumcraft.Infusion.removeRecipe(<thaumadditions:crystal_bag>);
 mods.thaumcraft.ArcaneWorkbench.registerShapedRecipe("crystal_bag", 
 "CRYSTALBAG", 
 100,
-[<aspect:aer>,<aspect:ignis>,<aspect:aqua>,<aspect:terra>,<aspect:ordo>,<aspect:perditio>], 
+[<aspect:aer>, <aspect:ignis>, <aspect:aqua>, <aspect:terra>, <aspect:ordo>, <aspect:perditio>], 
 <thaumadditions:crystal_bag>, 
   Grid(["pretty",
   "F Q F",
@@ -117,7 +117,7 @@ mods.thaumcraft.ArcaneWorkbench.removeRecipe("thaumadditions:fragnant_pendant");
 mods.thaumcraft.ArcaneWorkbench.registerShapedRecipe("fragnant_pendant", 
 "FRAGNANTPENDANT", 
 50,
-[<aspect:aer>,<aspect:ordo>,<aspect:aqua>],
+[<aspect:aer>, <aspect:ordo>, <aspect:aqua>],
 <thaumadditions:fragnant_pendant>,
   Grid(["pretty",
   "  F  ",
@@ -135,7 +135,7 @@ mods.thaumcraft.ArcaneWorkbench.removeRecipe(<thaumadditions:dawn_totem>);
 mods.thaumcraft.ArcaneWorkbench.registerShapedRecipe("dawn_totem", 
 "TOTEMANCY", 
 100,
-[<aspect:aer>,<aspect:ordo>], 
+[<aspect:aer>, <aspect:ordo>], 
 <thaumadditions:dawn_totem>*4, 
   Grid(["pretty",
   "W V W",
@@ -153,7 +153,7 @@ mods.thaumcraft.ArcaneWorkbench.removeRecipe(<thaumadditions:twilight_totem>);
 mods.thaumcraft.ArcaneWorkbench.registerShapedRecipe("twilight_totem", 
 "TOTEMANCY", 
 100,
-[<aspect:terra>,<aspect:perditio>], 
+[<aspect:terra>, <aspect:perditio>], 
 <thaumadditions:twilight_totem>*4, 
   Grid(["pretty",
   "W V W",
@@ -171,7 +171,7 @@ mods.thaumcraft.Infusion.removeRecipe(<thaumadditions:crystal_bore>);
 mods.thaumcraft.ArcaneWorkbench.registerShapedRecipe("crystal_bore", 
 "CRYSTALBORE", 
 20,
-[<aspect:terra>,<aspect:perditio>,<aspect:ordo>], 
+[<aspect:terra>, <aspect:perditio>, <aspect:ordo>], 
 <thaumadditions:crystal_bore>, 
   Grid(["pretty",
   "B V B",
@@ -204,7 +204,7 @@ mods.thaumcraft.Infusion.removeRecipe(<thaumadditions:growth_chamber>);
 mods.thaumcraft.ArcaneWorkbench.registerShapedRecipe("growth_chamber", 
 "GROWTHCHAMBER", 
 50,
-[<aspect:aer>,<aspect:ignis>,<aspect:aqua>,<aspect:terra>,<aspect:ordo>,<aspect:perditio>], 
+[<aspect:aer>, <aspect:ignis>, <aspect:aqua>, <aspect:terra>, <aspect:ordo>, <aspect:perditio>], 
 <thaumadditions:growth_chamber>, 
   Grid(["pretty",
   "B V B",
@@ -236,7 +236,7 @@ mods.thaumcraft.ArcaneWorkbench.removeRecipe("thaumadditions:seal_globe");
 mods.thaumcraft.ArcaneWorkbench.registerShapedRecipe("seal_globe", 
 "SEALGLOBE", 
 100,
-[<aspect:aer>,<aspect:ignis>,<aspect:aqua>,<aspect:terra>,<aspect:ordo>,<aspect:perditio>], 
+[<aspect:aer>, <aspect:ignis>, <aspect:aqua>, <aspect:terra>, <aspect:ordo>, <aspect:perditio>], 
 <thaumadditions:seal_globe>, 
   Grid(["pretty",
   "G G G",
@@ -253,7 +253,7 @@ mods.thaumcraft.ArcaneWorkbench.removeRecipe(<thaumadditions:bone_eye>);
 mods.thaumcraft.ArcaneWorkbench.registerShapedRecipe("bone_eye", 
 "CHESTER", 
 100,
-[<aspect:aer>,<aspect:ordo>], 
+[<aspect:aer>, <aspect:ordo>], 
 <thaumadditions:bone_eye>, 
   Grid(["pretty",
   "  Q S",
@@ -270,7 +270,7 @@ recipes.removeByRecipeName("hammercore:thaumadditions_recipestar.20");
 mods.thaumcraft.ArcaneWorkbench.registerShapedRecipe("essentia_sink", 
 "SHADOWBEAM", 
 100,
-[<aspect:ignis>,<aspect:aqua>*3], 
+[<aspect:ignis>, <aspect:aqua>*3], 
 <thaumadditions:essentia_sink>,
   Grid(["pretty",
   "J V J",
@@ -288,7 +288,7 @@ mods.thaumcraft.ArcaneWorkbench.removeRecipe(<thaumadditions:mithrillium_smelter
 mods.thaumcraft.ArcaneWorkbench.registerShapedRecipe("mithrillium_smelter", 
 "SMELTERMITHRILLIUM", 
 500,
-[<aspect:ignis>*6,<aspect:aqua>*3], 
+[<aspect:ignis>*6, <aspect:aqua>*3], 
 <thaumadditions:mithrillium_smelter>, 
   Grid(["pretty",
   "B S B",
@@ -305,7 +305,7 @@ mods.thaumcraft.ArcaneWorkbench.removeRecipe(<thaumadditions:adaminite_smelter>)
 mods.thaumcraft.ArcaneWorkbench.registerShapedRecipe("adaminite_smelter", 
 "SMELTERADAMINITE", 
 666,
-[<aspect:ignis>*12,<aspect:aqua>*6], 
+[<aspect:ignis>*12, <aspect:aqua>*6], 
 <thaumadditions:adaminite_smelter>, 
   Grid(["pretty",
   "B S B",
@@ -322,7 +322,7 @@ mods.thaumcraft.ArcaneWorkbench.removeRecipe(<thaumadditions:mithminite_smelter>
 mods.thaumcraft.ArcaneWorkbench.registerShapedRecipe("mithminite_smelter", 
 "SMELTERMITHMINITE", 
 1500,
-[<aspect:ignis>*24,<aspect:aqua>*12], 
+[<aspect:ignis>*24, <aspect:aqua>*12], 
 <thaumadditions:mithminite_smelter>, 
   Grid(["pretty",
   "B S B",
@@ -559,7 +559,7 @@ mods.thaumcraft.Crucible.registerRecipe(
   "FRAGNANTPENDANT", # Research
   <thaumadditions:odour_powder>*4, # Output
   <thaumcraft:bath_salts>, # Input
-  [<aspect:exitium>*5,<aspect:ordo>*5,<aspect:fluctus>*10]
+  [<aspect:exitium>*5, <aspect:ordo>*5, <aspect:fluctus>*10]
 );
 
 #[Blue bone]
@@ -587,7 +587,7 @@ mods.thaumcraft.Crucible.registerRecipe(
   "CRYSTALWATER", # Research
   <forge:bucketfilled>.withTag({FluidName: "crystal_water", Amount: 1000}), # Output
   <minecraft:bucket>, # Input
-  [<aspect:vitreus>*10,<aspect:desiderium>*4,<aspect:permutatio>*6]
+  [<aspect:vitreus>*10, <aspect:desiderium>*4, <aspect:permutatio>*6]
 );
 
 /*
@@ -606,7 +606,7 @@ mods.thaumcraft.Infusion.registerRecipe(
   "ACANECAKE", # Research
   <thaumadditions:cake>, # Output
   1, # Instability
-  [<aspect:victus> * 20, <aspect:praecantatio> * 15, <aspect:desiderium>*30, <aspect:ventus>*15,<aspect:imperium>*30],
+  [<aspect:victus>*20, <aspect:praecantatio>*15, <aspect:desiderium>*30, <aspect:ventus>*15, <aspect:imperium>*30],
   <minecraft:cake>, # CentralItem
   [<thaumcraft:primordial_pearl>.anyDamage(),<thaumcraft:quicksilver>,<thaumcraft:salis_mundus>,<thaumcraft:quicksilver>]
 );
@@ -618,7 +618,7 @@ mods.thaumcraft.Infusion.registerRecipe(
   "AURADISPENSER", # Research
   <thaumadditions:aura_disperser>, # Output
   1, # Instability
-  [<aspect:ventus>*30,<aspect:imperium>*50,<aspect:machina>*25,<aspect:fluctus>*15],
+  [<aspect:ventus>*30, <aspect:imperium>*50, <aspect:machina>*25, <aspect:fluctus>*15],
   <minecraft:dispenser>, # CentralItem
   [<thaumcraft:vishroom>,<thaumcraft:shimmerleaf>,<thaumadditions:salt_essence>.withTag({Aspects: [{amount: 1, key: "aer"}, {amount: 1, key: "aqua"}, {amount: 1, key: "perditio"}, {amount: 1, key: "ordo"}, {amount: 1, key: "ignis"}, {amount: 1, key: "terra"}]}),<thaumcraft:morphic_resonator>,<thaumcraft:mechanism_simple>,<thaumcraft:mechanism_simple>]
 );
@@ -630,7 +630,7 @@ mods.thaumcraft.Infusion.registerRecipe(
   "VOIDPICKAXE", # Research
   <thaumadditions:void_elemental_pickaxe>.withTag({infench: [{lvl: 1 as short, id: 4 as short}, {lvl: 2 as short, id: 3 as short}]}), # Output
   5, # Instability
-  [<aspect:exitium>*100, <aspect:ignis>*80,<aspect:sensus>*60,<aspect:alienis>*40],
+  [<aspect:exitium>*100, <aspect:ignis>*80, <aspect:sensus>*60, <aspect:alienis>*40],
   <thaumcraft:elemental_pick>.anyDamage(), # CentralItem
   [<thaumcraft:primordial_pearl>.anyDamage(),<thaumcraft:plate:3>,<thaumcraft:plate:3>]
 );
@@ -642,7 +642,7 @@ mods.thaumcraft.Infusion.registerRecipe(
   "VOIDAXE", # Research
   <thaumadditions:void_elemental_axe>.withTag({infench: [{lvl: 1 as short, id: 2 as short}, {lvl: 1 as short, id: 0 as short}]}), # Output
   5, # Instability
-  [<aspect:herba>*200,<aspect:aqua>*100,<aspect:alienis>*40],
+  [<aspect:herba>*200, <aspect:aqua>*100, <aspect:alienis>*40],
   <thaumcraft:elemental_axe>.anyDamage(), # CentralItem
   [<thaumcraft:primordial_pearl>.anyDamage(),<thaumcraft:plate:3>,<thaumcraft:plate:3>]
 );
@@ -654,7 +654,7 @@ mods.thaumcraft.Infusion.registerRecipe(
   "VOIDSHOVEL", # Research
   <thaumadditions:void_elemental_shovel>.withTag({infench: [{lvl: 1 as short, id: 1 as short}]}), # Output
   5, # Instability
-  [<aspect:exitium>*100,<aspect:terra>*100,<aspect:fabrico>*80,<aspect:alienis>*40],
+  [<aspect:exitium>*100, <aspect:terra>*100, <aspect:fabrico>*80, <aspect:alienis>*40],
   <thaumcraft:elemental_shovel>.anyDamage(), # CentralItem
   [<thaumcraft:primordial_pearl>.anyDamage(),<thaumcraft:plate:3>,<thaumcraft:plate:3>]
 );
@@ -666,7 +666,7 @@ mods.thaumcraft.Infusion.registerRecipe(
   "VOIDHOE", # Research
   <thaumadditions:void_elemental_hoe>, # Output
   5, # Instability
-  [<aspect:herba>*200,<aspect:victus>*100,<aspect:alienis>*40],
+  [<aspect:herba>*200, <aspect:victus>*100, <aspect:alienis>*40],
   <thaumcraft:elemental_hoe>.anyDamage(), # CentralItem
   [<thaumcraft:primordial_pearl>.anyDamage(),<thaumcraft:plate:3>,<thaumcraft:plate:3>]
 );
@@ -678,7 +678,7 @@ mods.thaumcraft.Infusion.registerRecipe(
   "VOIDCROP", # Research
   <thaumadditions:void_seed>, # Output
   8, # Instability
-  [<aspect:aer>*20,<aspect:ignis>*20,<aspect:aqua>*20,<aspect:terra>*20,<aspect:ordo>*20,<aspect:perditio>*20,<aspect:caeles>*50,<aspect:tenebrae>*100],
+  [<aspect:aer>*20, <aspect:ignis>*20, <aspect:aqua>*20, <aspect:terra>*20, <aspect:ordo>*20, <aspect:perditio>*20, <aspect:caeles>*50, <aspect:tenebrae>*100],
   <thaumcraft:elemental_hoe>.anyDamage(), # CentralItem
   [<thaumcraft:primordial_pearl>.anyDamage(),<botania:specialflower>.withTag({type: "excompressum.orechidEvolved"}),<thaumcraft:metal_void>,<botania:specialflower>.withTag({type: "orechidIgnem"}),<thaumcraft:salis_mundus>,<botania:specialflower>.withTag({type: "orechidVacuam"})]
 );
@@ -690,7 +690,7 @@ mods.thaumcraft.Infusion.registerRecipe(
   "VOIDANVIL", # Research
   <thaumadditions:void_anvil>, # Output
   5, # Instability
-  [<aspect:caeles>*20,<aspect:metallum>*100,<aspect:alienis>*150],
+  [<aspect:caeles>*20, <aspect:metallum>*100, <aspect:alienis>*150],
   <cyclicmagic:block_anvil_magma>, # CentralItem
   [<thaumcraft:plate:3>,<thaumcraft:plate:3>,<thaumcraft:plate:3>,<thaumcraft:plate:3>]
 );
@@ -702,7 +702,7 @@ mods.thaumcraft.Infusion.registerRecipe(
   "VOIDMIRROR", # Research
   <thaumadditions:wormhole_mirror>, # Output
   5, # Instability
-  [<aspect:imperium>*100,<aspect:visum>*80,<aspect:alienis>*40],
+  [<aspect:imperium>*100, <aspect:visum>*80, <aspect:alienis>*40],
   <thaumcraft:hand_mirror>, # CentralItem
   [<thaumadditions:void_thaumometer>,<thaumcraft:plate:3>,<thaumcraft:plate:3>]
 );
@@ -714,7 +714,7 @@ mods.thaumcraft.Infusion.registerRecipe(
   "TRAVELLERBELT", # Research
   <thaumadditions:traveller_belt>, # Output
   2, # Instability
-  [<aspect:motus>*100,<aspect:volatus>*100],
+  [<aspect:motus>*100, <aspect:volatus>*100],
   <thaumcraft:baubles:2>, # CentralItem
   [<thaumcraft:crystal_essence>.withTag({Aspects: [{amount: 1, key: "aer"}]}),<thaumcraft:crystal_essence>.withTag({Aspects: [{amount: 1, key: "aer"}]}),<ore:fish>,<ore:feather>,<thaumcraft:fabric>,<thaumcraft:fabric>]
 );
@@ -726,7 +726,7 @@ mods.thaumcraft.Infusion.registerRecipe(
   "STRIDINGBELT", # Research
   <thaumadditions:striding_belt>, # Output
   3, # Instability
-  [<aspect:mana>*50,<aspect:fluctus>*100,<aspect:sonus>*50,<aspect:volatus>*50,<aspect:ventus>*50],
+  [<aspect:mana>*50, <aspect:fluctus>*100, <aspect:sonus>*50, <aspect:volatus>*50, <aspect:ventus>*50],
   <thaumadditions:traveller_belt>, # CentralItem
   [<ore:peacockFeathers>,<thaumcraft:amber_block>,<ore:peacockFeathers>,<botania:spark>,<ore:peacockFeathers>,<thaumcraft:amber_block>,<ore:peacockFeathers>,<thaumcraft:inlay>]
 );
@@ -738,7 +738,7 @@ mods.thaumcraft.Infusion.registerRecipe(
   "METEORBELT", # Research
   <thaumadditions:meteor_belt>, # Output
   5, # Instability
-  [<aspect:infernum>*200,<aspect:fluctus>*50,<aspect:motus>*200,<aspect:caeles>*25,<aspect:sanguis>*100],
+  [<aspect:infernum>*200, <aspect:fluctus>*50, <aspect:motus>*200, <aspect:caeles>*25, <aspect:sanguis>*100],
   <thaumadditions:striding_belt>, # CentralItem
   [<twilightforest:carminite>,<thaumadditions:zeith_fur>,<twilightforest:carminite>,<bloodmagic:slate:1>,<twilightforest:carminite>,<thaumadditions:zeith_fur>,<twilightforest:carminite>,<bloodmagic:slate:1>]
 );
@@ -750,7 +750,7 @@ mods.thaumcraft.Infusion.registerRecipe(
   "CHESTER", # Research
   <thaumadditions:chester>, # Output
   2, # Instability
-  [<aspect:imperium>*80,<aspect:victus>*50,<aspect:motus>*40,<aspect:vacuos>*20,<aspect:machina>*10],
+  [<aspect:imperium>*80, <aspect:victus>*50, <aspect:motus>*40, <aspect:vacuos>*20, <aspect:machina>*10],
   <thaumcraft:hungry_chest>, # CentralItem
   [<thaumcraft:brain>,<thaumcraft:log_greatwood>,<thaumcraft:ingot>,<thaumcraft:log_greatwood>,<thaumcraft:morphic_resonator>,<thaumcraft:log_greatwood>,<thaumcraft:ingot>,<thaumcraft:log_greatwood>]
 );
@@ -762,7 +762,7 @@ mods.thaumcraft.Infusion.registerRecipe(
   "FLUXCONCENTRATOR", # Research
   <thaumadditions:flux_concentrator>, # Output
   2, # Instability
-  [<aspect:permutatio>*50,<aspect:machina>*30,<aspect:vitium>*100],
+  [<aspect:permutatio>*50, <aspect:machina>*30, <aspect:vitium>*100],
   <thaumcraft:mechanism_complex>, # CentralItem
   [<thaumcraft:vishroom>,<thaumcraft:morphic_resonator>,<thaumcraft:vishroom>,<thaumcraft:bellows>]
 );
@@ -774,7 +774,7 @@ mods.thaumcraft.Infusion.registerRecipe(
   "MITHRILLIUM", # Research
   <thaumadditions:mithrillium_block>, # Output
   3, # Instability
-  [<aspect:mana>*200,<aspect:alienis>*100,<aspect:praecantatio>*150],
+  [<aspect:mana>*200, <aspect:alienis>*100, <aspect:praecantatio>*150],
   <thaumcraft:metal_void>, # CentralItem
   [<botania:quartztypemana>,<botania:quartztypemana>,<thaumicaugmentation:material:5>,<botania:quartztypemana>,<botania:quartztypemana>,<thaumicaugmentation:material:5>]
 );
@@ -786,7 +786,7 @@ mods.thaumcraft.Infusion.registerRecipe(
   "ADAMINITE", # Research
   <thaumadditions:adaminite_block>, # Output
   5, # Instability
-  [<aspect:sanguis>*200,<aspect:infernum>*666,<aspect:spiritus>*200],
+  [<aspect:sanguis>*200, <aspect:infernum>*666, <aspect:spiritus>*200],
   <thaumadditions:mithrillium_block>, # CentralItem
   [<bloodmagic:blood_shard>,<bloodmagic:slate>,<tconstruct:materials:11>,<bloodmagic:blood_shard>,<bloodmagic:slate>,<tconstruct:materials:11>]
 );
@@ -798,7 +798,7 @@ mods.thaumcraft.Infusion.registerRecipe(
   "MITHMINITE", # Research
   <thaumadditions:mithminite_block>, # Output
   8, # Instability
-  [<aspect:draco>*200,<aspect:caeles>*200,<aspect:mythus>*200,<aspect:praecantatio>*300],
+  [<aspect:draco>*200, <aspect:caeles>*200, <aspect:mythus>*200, <aspect:praecantatio>*300],
   <thaumadditions:adaminite_block>, # CentralItem
   [<ore:dragonscaleBlock>,<thaumcraft:quicksilver>,<iceandfire:pixie_dust>,<ore:dragonscaleBlock>,<thaumcraft:quicksilver>,<iceandfire:pixie_dust>]
 );
@@ -810,7 +810,7 @@ mods.thaumcraft.Infusion.registerRecipe(
   "MITHRILLIUM", # Research
   <thaumadditions:mithrillium_resonator>, # Output
   4, # Instability
-  [<aspect:imperium>*20,<aspect:mana>*30],
+  [<aspect:imperium>*20, <aspect:mana>*30],
   <thaumcraft:morphic_resonator>, # CentralItem
   [<thaumadditions:mithrillium_plate>,<thaumadditions:mithrillium_plate>,<thaumicaugmentation:material:5>]
 );
@@ -822,7 +822,7 @@ mods.thaumcraft.Infusion.registerRecipe(
   "SHADOWENCHANTER", # Research
   <thaumadditions:shadow_enchanter>, # Output
   6, # Instability
-  [<aspect:caeles>*50,<aspect:praecantatio>*100,<aspect:instrumentum>*100,<aspect:cognitio>*500],
+  [<aspect:caeles>*50, <aspect:praecantatio>*100, <aspect:instrumentum>*100, <aspect:cognitio>*500],
   <cyclicmagic:block_enchanter>, # CentralItem
   [<thaumadditions:mithrillium_resonator>,<extrautils2:ingredients:12>,<thaumcraft:mechanism_complex>,<thaumadditions:mithrillium_resonator>,<extrautils2:ingredients:12>,<thaumcraft:mechanism_complex>,<thaumicwonders:disjunction_cloth>]
 );
@@ -834,7 +834,7 @@ mods.thaumcraft.Infusion.registerRecipe(
   "SHADOWENCHANTER", # Research
   <thaumadditions:the_beheader>, # Output
   3, # Instability
-  [<aspect:mortuus>*100,<aspect:spiritus>*50,<aspect:exanimis>*100],
+  [<aspect:mortuus>*100, <aspect:spiritus>*50, <aspect:exanimis>*100],
   <thaumcraft:void_axe>, # CentralItem
   [<ore:itemSkull>,<ore:itemSkull>,<thaumadditions:mithrillium_plate>,<ore:itemSkull>,<ore:itemSkull>,<thaumadditions:mithrillium_plate>]
 );
@@ -846,7 +846,7 @@ mods.thaumcraft.Infusion.registerRecipe(
   "SHADOWBEAM", # Research
   <thaumadditions:shadow_beam_staff>, # Output
   4, # Instability
-  [<aspect:alienis>*300,<aspect:potentia>*150,<aspect:praecantatio>*100,<aspect:draco>*20],
+  [<aspect:alienis>*300, <aspect:potentia>*150, <aspect:praecantatio>*100, <aspect:draco>*20],
   <iceandfire:dragonbone>, # CentralItem
   [<thaumadditions:mithrillium_plate>,<biomesoplenty:gem:4>,<biomesoplenty:gem:4>,<thaumadditions:mithrillium_plate>,<thaumadditions:mithrillium_resonator>]
 );
@@ -858,7 +858,7 @@ mods.thaumcraft.Infusion.registerRecipe(
   "ADAMINITESWORD", # Research
   <thaumadditions:adaminite_sword>, # Output
   6, # Instability
-  [<aspect:infernum>*666,<aspect:aversio>*100,<aspect:potentia>*200,<aspect:caeles>*50,<aspect:draco>*50,<aspect:sanguis>*150],
+  [<aspect:infernum>*666, <aspect:aversio>*100, <aspect:potentia>*200, <aspect:caeles>*50, <aspect:draco>*50, <aspect:sanguis>*150],
   <thaumcraft:void_sword>, # CentralItem
   [<thaumadditions:adaminite_plate>,<thaumadditions:adaminite_plate>,<thaumadditions:adaminite_plate>,<bloodmagic:slate:3>]
 );
@@ -870,7 +870,7 @@ mods.thaumcraft.Infusion.registerRecipe(
   "COMBINER", # Research
   <thaumadditions:aspect_combiner>, # Output
   2, # Instability
-  [<aspect:praecantatio>*50,<aspect:alkimia>*200,<aspect:machina>*100,<aspect:visum>*50,<aspect:imperium>*100],
+  [<aspect:praecantatio>*50, <aspect:alkimia>*200, <aspect:machina>*100, <aspect:visum>*50, <aspect:imperium>*100],
   <thaumcraft:centrifuge>, # CentralItem
   [<thaumadditions:mithrillium_resonator>,<thaumcraft:mechanism_complex>,<thaumcraft:filter>,<thaumcraft:alumentum>,<thaumictinkerer:energetic_nitor>,<thaumcraft:filter>]
 );
@@ -882,7 +882,7 @@ mods.thaumcraft.Infusion.registerRecipe(
   "AURACHARGER", # Research
   <thaumadditions:aura_charger>, # Output
   5, # Instability
-  [<aspect:auram>*200,<aspect:machina>*50,<aspect:alienis>*100,<aspect:fluctus>*100],
+  [<aspect:auram>*200, <aspect:machina>*50, <aspect:alienis>*100, <aspect:fluctus>*100],
   <thaumadditions:aura_disperser>, # CentralItem
   [<thaumadditions:adaminite_plate>,<thaumcraft:mechanism_complex>,<thaumadditions:adaminite_plate>,<thaumadditions:mithrillium_resonator>]
 );
@@ -894,7 +894,7 @@ mods.thaumcraft.Infusion.registerRecipe(
   "MITHMINITESCYTHE", # Research
   <thaumadditions:mithminite_blade>, # Output
   6, # Instability
-  [<aspect:aversio>*200,<aspect:exanimis>*100,<aspect:mortuus>*100,<aspect:infernum>*666,<aspect:sanguis>*200],
+  [<aspect:aversio>*200, <aspect:exanimis>*100, <aspect:mortuus>*100, <aspect:infernum>*666, <aspect:sanguis>*200],
   <thaumadditions:mithminite_ingot>, # CentralItem
   [<thaumadditions:mithminite_plate>,<thaumicaugmentation:material:5>,<thaumadditions:mithminite_plate>,<thaumicaugmentation:material:5>]
 );
@@ -906,7 +906,7 @@ mods.thaumcraft.Infusion.registerRecipe(
   "MITHMINITESCYTHE", # Research
   <thaumadditions:mithminite_handle>, # Output
   6, # Instability
-  [<aspect:mana>*200,<aspect:motus>*100,<aspect:potentia>*200,<aspect:spiritus>*100,<aspect:mythus>*100],
+  [<aspect:mana>*200, <aspect:motus>*100, <aspect:potentia>*200, <aspect:spiritus>*100, <aspect:mythus>*100],
   <iceandfire:dragonbone>, # CentralItem
   [<thaumadditions:mithminite_plate>,<bloodmagic:item_demon_crystal>,<thaumadditions:mithminite_plate>,<bloodmagic:item_demon_crystal>]
 );
@@ -918,7 +918,7 @@ mods.thaumcraft.Infusion.registerRecipe(
   "MITHMINITESCYTHE", # Research
   <thaumadditions:mithminite_scythe>, # Output
   13, # Instability
-  [<aspect:draco>*200,<aspect:caeles>*200,<aspect:amogus>*100],
+  [<aspect:draco>*200, <aspect:caeles>*200, <aspect:amogus>*100],
   <thaumcraft:crystal_essence>.withTag({Aspects: [{amount: 1, key: "amogus"}]}), # CentralItem
   [<thaumadditions:mithminite_handle>,<thaumadditions:mithminite_plate>,<thaumadditions:mithminite_blade>,<thaumadditions:mithminite_plate>]
 );
@@ -930,7 +930,7 @@ mods.thaumcraft.Infusion.registerRecipe(
   "SPAWNER", # Research
   <thaumadditions:entity_summoner>, # Output
   3, # Instability
-  [<aspect:victus>*100,<aspect:spiritus>*100,<aspect:alienis>*100,<aspect:imperium>*100],
+  [<aspect:victus>*100, <aspect:spiritus>*100, <aspect:alienis>*100, <aspect:imperium>*100],
   <enderio:item_broken_spawner>, # CentralItem
   [<thaumcraft:mechanism_complex>,<thaumicaugmentation:material:5>,<thaumadditions:twilight_totem>,<thaumcraft:mechanism_complex>,<thaumicaugmentation:material:5>,<thaumadditions:dawn_totem>]
 );
@@ -941,7 +941,7 @@ mods.thaumcraft.Infusion.registerRecipe(
   "VISCHARM", # Research
   <thaumadditions:recharge_charm>, # Output
   2, # Instability
-  [<aspect:auram>*80,<aspect:vacuos>*60],
+  [<aspect:auram>*80, <aspect:vacuos>*60],
   <thaumcraft:verdant_charm:*>, # CentralItem
   [<thaumcraft:crystal_essence>.withTag({Aspects: [{amount: 1, key: "vacuos"}]}),<thaumcraft:vis_resonator>,<minecraft:potion>.withTag({Potion: "potioncore:strong_bless"}),<thaumcraft:crystal_essence>.withTag({Aspects: [{amount: 1, key: "auram"}]}),]
 );
@@ -953,7 +953,7 @@ mods.thaumcraft.Infusion.registerRecipe(
   "BOOTSTRAVELLER", # Research
   <thaumcraft:traveller_boots>, # Output
   1, # Instability
-  [<aspect:volatus>*100,<aspect:motus>*100],
+  [<aspect:volatus>*100, <aspect:motus>*100],
   <thaumcraft:cloth_boots:*>, # CentralItem
   [<thaumcraft:crystal_essence>.withTag({Aspects: [{amount: 1, key: "aer"}]}),<thaumcraft:crystal_essence>.withTag({Aspects: [{amount: 1, key: "aer"}]}),<thaumcraft:fabric>,<thaumcraft:fabric>,<ore:feather>,<ore:fish>]
 );

--- a/scripts/mods/thaumcraft.zs
+++ b/scripts/mods/thaumcraft.zs
@@ -1078,3 +1078,25 @@ scripts.jei.crafting_hints.addInsOutCatl([<thaumicwonders:primordial_grain>], <t
 
 <entity:thaumcraft:firebat>.addDrop(<randomthings:flootoken>, 1, 3);
 <entity:thaumcraft:thaumslime>.addPlayerOnlyDrop(<thermalexpansion:florb>.withTag({Fluid: "liquiddna"}) % 30, 1, 1);
+
+# Tattered scrolls alt recipe
+mods.astralsorcery.Altar.addConstellationAltarRecipe(
+  'Tattered Scrolls alt', <thaumicaugmentation:research_notes>, 1500, 250, Grid([
+  "KCK"+
+  "NIN"+
+  "KVK"+
+  "LERP"+
+  "HHGGGGHH"], {
+  "K": <astralsorcery:itemknowledgeshare>,  # Scroll of written expertise
+  "V": <thaumadditions:void_fruit>,         # Void fruit
+  "C": <thaumcraft:curiosity_band>,         # Curiosity band
+  "I": <thaumicaugmentation:material:3>,    # Impetus Cell
+  "G": <thaumicwonders:primordial_grain>,   # Primordial grain
+  "H": <warptheory:item_something>,         # Hunk of Somethink
+  "N": <enderio:item_material:75>,          # Infinity reagent
+  "L": <botania:rune:9>,                    # Rune of Lust
+  "E": <botania:rune:14>,                   # Rune of Envy
+  "R": <botania:rune:11>,                   # Rune of Greed
+  "P": <botania:rune:15>,                   # Rune of Pride
+  }).shapeless()
+);

--- a/scripts/mods/thaumcraft.zs
+++ b/scripts/mods/thaumcraft.zs
@@ -983,6 +983,68 @@ mods.thaumcraft.Crucible.registerRecipe(
   [<aspect:potentia>*10, <aspect:ignis>*10, <aspect:perditio>*5]
 );
 
+# [Energetic nitor]
+mods.thaumcraft.Crucible.removeRecipe(<thaumictinkerer:energetic_nitor>);
+mods.thaumcraft.Crucible.registerRecipe(
+  "energetic_nitor", # Name
+  "TT_ENERGETIC_NITOR", # Research
+  <thaumictinkerer:energetic_nitor>, # Output
+  <ore:nitor>, # Input
+  [<aspect:lux>*25, <aspect:potentia>*25, <aspect:ignis>*10, <aspect:aer>*10]
+);
+
+# Native cluster fix
+function NativeClusterRecipe(name as string, native as IItemStack, ore as IItemStack) as void {
+	mods.thaumcraft.Crucible.removeRecipe(native);
+  mods.thaumcraft.Crucible.registerRecipe(
+  name, # Name
+  "METALPURIFICATION", # Research
+  native, # Output
+  ore, # Input
+  [<aspect:ordo>*5, <aspect:metallum>*5]
+  );
+}
+
+NativeClusterRecipe("metal_purification_aluminium"            , <jaopca:item_clusteraluminium>            , <thermalfoundation:ore:4>);
+NativeClusterRecipe("metal_purification_nickel"               , <jaopca:item_clusternickel>               , <thermalfoundation:ore:5>);
+NativeClusterRecipe("metal_purification_iridium"              , <jaopca:item_clusteriridium>              , <thermalfoundation:ore:7>);
+NativeClusterRecipe("metal_purification_platinum"             , <jaopca:item_clusterplatinum>             , <thermalfoundation:ore:6>);
+NativeClusterRecipe("metal_purification_uranium"              , <jaopca:item_clusteruranium>              , <immersiveengineering:ore:5>);
+NativeClusterRecipe("metal_purification_osmium"               , <jaopca:item_clusterosmium>               , <mekanism:oreblock>);
+NativeClusterRecipe("metal_purification_ardite"               , <jaopca:item_clusterardite>               , <tconstruct:ore:1>);
+NativeClusterRecipe("metal_purification_cobalt"               , <jaopca:item_clustercobalt>               , <tconstruct:ore>);
+NativeClusterRecipe("metal_purification_tungsten"             , <jaopca:item_clustertungsten>             , <endreborn:block_wolframium_ore>);
+NativeClusterRecipe("metal_purification_starmetal"            , <jaopca:item_clusterastralstarmetal>      , <astralsorcery:blockcustomore:1>);
+NativeClusterRecipe("metal_purification_boron"                , <jaopca:item_clusterboron>                , <nuclearcraft:ore:5>);
+NativeClusterRecipe("metal_purification_lithium"              , <jaopca:item_clusterlithium>              , <nuclearcraft:ore:6>);
+NativeClusterRecipe("metal_purification_magnesium"            , <jaopca:item_clustermagnesium>            , <nuclearcraft:ore:7>);
+NativeClusterRecipe("metal_purification_thorium"              , <jaopca:item_clusterthorium>              , <nuclearcraft:ore:3>);
+NativeClusterRecipe("metal_purification_manainfusedingot"     , <jaopca:item_clustermithril>              , <thermalfoundation:ore:8>);
+NativeClusterRecipe("metal_purification_blackquartz"          , <jaopca:item_clusterquartzblack>          , <actuallyadditions:block_misc:3>);
+NativeClusterRecipe("metal_purification_draconium"            , <jaopca:item_clusterdraconium>            , <draconicevolution:draconium_ore>);
+NativeClusterRecipe("metal_purification_titanium"             , <jaopca:item_clustertitanium>             , <libvulpes:ore0:8>);
+NativeClusterRecipe("metal_purification_coal"                 , <jaopca:item_clustercoal>                 , <minecraft:coal_ore>);
+NativeClusterRecipe("metal_purification_emerald"              , <jaopca:item_clusteremerald>              , <minecraft:emerald_ore>);
+NativeClusterRecipe("metal_purification_lapis"                , <jaopca:item_clusterlapis>                , <minecraft:lapis_ore>);
+NativeClusterRecipe("metal_purification_redstone"             , <jaopca:item_clusterredstone>             , <minecraft:redstone_ore>);
+NativeClusterRecipe("metal_purification_diamond"              , <jaopca:item_clusterdiamond>              , <minecraft:diamond_ore>);
+NativeClusterRecipe("metal_purification_dimensionalshard"     , <jaopca:item_clusterdimensionalshard>     , <rftools:dimensional_shard_ore>);
+NativeClusterRecipe("metal_purification_dilithium"            , <jaopca:item_clusterdilithium>            , <libvulpes:ore0>);
+NativeClusterRecipe("metal_purification_certusquartz"         , <jaopca:item_clustercertusquartz>         , <appliedenergistics2:quartz_ore>);
+NativeClusterRecipe("metal_purification_chargedcertusquartz"  , <jaopca:item_clusterchargedcertusquartz>  , <appliedenergistics2:charged_quartz_ore>);
+NativeClusterRecipe("metal_purification_aquamarine"           , <jaopca:item_clusteraquamarine>           , <astralsorcery:blockcustomsandore>);
+NativeClusterRecipe("metal_purification_apatite"              , <jaopca:item_clusterapatite>              , <forestry:resources>);
+NativeClusterRecipe("metal_purification_amber"                , <jaopca:item_clusteramber>                , <biomesoplenty:gem_ore:7>);
+NativeClusterRecipe("metal_purification_amberthaumcraft"      , <jaopca:item_clusteramber>                , <thaumcraft:ore_amber>);
+NativeClusterRecipe("metal_purification_trinitite"            , <jaopca:item_clustertrinitite>            , <trinity:trinitite>);
+NativeClusterRecipe("metal_purification_malachite"            , <jaopca:item_clustermalachite>            , <biomesoplenty:gem_ore:5>);
+NativeClusterRecipe("metal_purification_topaz"                , <jaopca:item_clustertopaz>                , <biomesoplenty:gem_ore:3>);
+NativeClusterRecipe("metal_purification_tanzanite"            , <jaopca:item_clustertanzanite>            , <biomesoplenty:gem_ore:4>);
+NativeClusterRecipe("metal_purification_sapphire"             , <jaopca:item_clustersapphire>             , <biomesoplenty:gem_ore:6>);
+NativeClusterRecipe("metal_purification_ruby"                 , <jaopca:item_clusterruby>                 , <biomesoplenty:gem_ore:1>);
+NativeClusterRecipe("metal_purification_peridot"              , <jaopca:item_clusterperidot>              , <biomesoplenty:gem_ore:2>);
+NativeClusterRecipe("metal_purification_amethyst"             , <jaopca:item_clusteramethyst>             , <biomesoplenty:gem_ore>);
+
 /*
  ██████╗ ████████╗██╗  ██╗███████╗██████╗ 
 ██╔═══██║╚══██╔══╝██║  ██║██╔════╝██╔══██╗

--- a/scripts/mods/thaumcraft.zs
+++ b/scripts/mods/thaumcraft.zs
@@ -380,7 +380,7 @@ mods.thaumcraft.ArcaneWorkbench.removeRecipe("thaumcraft:thaumometer");
 mods.thaumcraft.ArcaneWorkbench.registerShapedRecipe("thaumometer", 
 "FIRSTSTEPS@2", 
 20,
-[<aspect:aer>,<aspect:ignis>,<aspect:aqua>,<aspect:terra>,<aspect:ordo>,<aspect:perditio>], 
+[<aspect:aer>, <aspect:ignis>, <aspect:aqua>, <aspect:terra>, <aspect:ordo>, <aspect:perditio>], 
 <thaumcraft:thaumometer>, 
   Grid(["pretty",
   "  C  ",
@@ -395,7 +395,7 @@ mods.thaumcraft.ArcaneWorkbench.removeRecipe("thaumcraft:thaumometer");
 mods.thaumcraft.ArcaneWorkbench.registerShapedRecipe("thaumometer", 
 "FIRSTSTEPS@2", 
 20,
-[<aspect:aer>,<aspect:ignis>,<aspect:aqua>,<aspect:terra>,<aspect:ordo>,<aspect:perditio>], 
+[<aspect:aer>, <aspect:ignis>, <aspect:aqua>, <aspect:terra>, <aspect:ordo>, <aspect:perditio>], 
 <thaumcraft:thaumometer>, 
   Grid(["pretty",
   "  C  ",
@@ -410,7 +410,7 @@ mods.thaumcraft.ArcaneWorkbench.removeRecipe("thaumcraft:vis_resonator");
 mods.thaumcraft.ArcaneWorkbench.registerShapedRecipe("vis_resonator", 
 "UNLOCKAUROMANCY@1", 
 20,
-[<aspect:aer>,<aspect:terra>], 
+[<aspect:aer>, <aspect:terra>], 
 <thaumcraft:vis_resonator>, 
   Grid(["pretty",
   "A A A",
@@ -471,7 +471,7 @@ mods.thaumcraft.ArcaneWorkbench.removeRecipe("thaumcraft:alchemicalconstruct");
 mods.thaumcraft.ArcaneWorkbench.registerShapedRecipe("alchemicalconstruct", 
 "TUBES", 
 50,
-[<aspect:aer>*2,<aspect:ignis>*2,<aspect:aqua>*2,<aspect:terra>*2,<aspect:ordo>*2,<aspect:perditio>*2], 
+[<aspect:aer>*2, <aspect:ignis>*2, <aspect:aqua>*2, <aspect:terra>*2, <aspect:ordo>*2, <aspect:perditio>*2], 
 <thaumcraft:metal_alchemical>*2, 
   Grid(["pretty",
   "G T G",
@@ -534,7 +534,7 @@ mods.thaumcraft.ArcaneWorkbench.removeRecipe("thaumcraft:condenserlattice");
 mods.thaumcraft.ArcaneWorkbench.registerShapedRecipe("condenserlattice", 
 "FLUXCLEANUP", 
 25,
-[<aspect:aer>,<aspect:terra>], 
+[<aspect:aer>, <aspect:terra>], 
 <thaumcraft:condenser_lattice>*8, 
   Grid(["pretty",
   "S Q S",
@@ -550,7 +550,7 @@ mods.thaumcraft.ArcaneWorkbench.removeRecipe("thaumcraft:bellows");
 mods.thaumcraft.ArcaneWorkbench.registerShapedRecipe("bellows", 
 "BELLOWS", 
 25,
-[<aspect:aer>,<aspect:terra>], 
+[<aspect:aer>, <aspect:terra>], 
 <thaumcraft:bellows>, 
   Grid(["pretty",
   "W W  ",
@@ -584,7 +584,7 @@ mods.thaumcraft.ArcaneWorkbench.removeRecipe("thaumcraft:smelteraux");
 mods.thaumcraft.ArcaneWorkbench.registerShapedRecipe("smelteraux", 
 "IMPROVEDSMELTING", 
 100,
-[<aspect:aer>,<aspect:terra>], 
+[<aspect:aer>, <aspect:terra>], 
 <thaumcraft:smelter_aux>, 
   Grid(["pretty",
   "B T B",
@@ -602,7 +602,7 @@ mods.thaumcraft.ArcaneWorkbench.removeRecipe("thaumcraft:essentiatransportout");
 mods.thaumcraft.ArcaneWorkbench.registerShapedRecipe("essentiatransportout", 
 "ESSENTIATRANSPORT", 
 100,
-[<aspect:aer>,<aspect:aqua>], 
+[<aspect:aer>, <aspect:aqua>], 
 <thaumcraft:essentia_output>, 
   Grid(["pretty",
   "B H B",
@@ -618,7 +618,7 @@ mods.thaumcraft.ArcaneWorkbench.removeRecipe("thaumcraft:essentiatransportin");
 mods.thaumcraft.ArcaneWorkbench.registerShapedRecipe("essentiatransportin", 
 "ESSENTIATRANSPORT", 
 100,
-[<aspect:aer>,<aspect:aqua>], 
+[<aspect:aer>, <aspect:aqua>], 
 <thaumcraft:essentia_input>, 
   Grid(["pretty",
   "B D B",
@@ -821,7 +821,7 @@ mods.thaumcraft.Infusion.registerRecipe(
   "TCONEVO_PRIMALMETAL", # Research
   <tconevo:metal:20>, # Output
   2, # Instability
-  [<aspect:aer>*10,<aspect:ignis>*10,<aspect:ordo>*10,<aspect:aqua>*10,<aspect:terra>*10,<aspect:perditio>*10,<aspect:metallum>*30],
+  [<aspect:aer>*10, <aspect:ignis>*10, <aspect:ordo>*10, <aspect:aqua>*10, <aspect:terra>*10, <aspect:perditio>*10, <aspect:metallum>*30],
   <tconevo:material>, # CentralItem
   [<thaumicwonders:primordial_grain>,<thaumcraft:salis_mundus>]
 );
@@ -970,7 +970,7 @@ mods.thaumcraft.Crucible.registerRecipe(
   "BASEAUROMANCY@1", # Research
   <thaumcraft:focus_1>, # Output
   <thaumcraft:quicksilver>, # Input
-  [<aspect:auram> * 5,<aspect:praecantatio>*10,<aspect:vitreus>*20]
+  [<aspect:auram>*5, <aspect:praecantatio>*10, <aspect:vitreus>*20]
 );
 
 # [Alumentum]
@@ -980,7 +980,7 @@ mods.thaumcraft.Crucible.registerRecipe(
   "ALUMENTUM", # Research
   <thaumcraft:alumentum>*10, # Output
   <minecraft:coal>, # Input
-  [<aspect:potentia> * 10,<aspect:ignis>*10,<aspect:perditio>*5]
+  [<aspect:potentia>*10, <aspect:ignis>*10, <aspect:perditio>*5]
 );
 
 /*

--- a/scripts/mods/thaumcraft_aspects.zs
+++ b/scripts/mods/thaumcraft_aspects.zs
@@ -13,6 +13,557 @@ import thaumcraft.aspect.CTAspectStack;
 ╚═╝  ╚═╝╚══════╝╚═╝     ╚══════╝ ╚═════╝   ╚═╝   ╚══════╝
 */
 
+/*
+#######################################################
+
+Animus
+
+#######################################################
+*/
+
+<animus:component>                              .setAspects(<aspect:praecantatio>*5  ,<aspect:fabrico>*10); #reagent builder T1
+<animus:component:1>                            .setAspects(<aspect:praecantatio>*15 ,<aspect:imperium>*20); #reagent chains T3
+<animus:component:2>                            .setAspects(<aspect:praecantatio>*15 ,<aspect:rattus>*40); #reagent consumption T3
+<animus:component:3>                            .setAspects(<aspect:praecantatio>*10 ,<aspect:desiderium>*30); #reagent leech T2
+<animus:component:4>                            .setAspects(<aspect:praecantatio>*10 ,<aspect:potentia>*50); #reagent storm T2
+<animus:component:5>                            .setAspects(<aspect:praecantatio>*20 ,<aspect:motus>*20); #reagent acquisition T4
+
+<animus:sigil_builder>                          .setAspects(<aspect:praecantatio>*5  ,<aspect:sanguis>*5         ,<aspect:fabrico>*10); #sigil builder T1
+<animus:sigil_chains>                           .setAspects(<aspect:praecantatio>*15 ,<aspect:sanguis>*30        ,<aspect:imperium>*30); #sigil chains T3
+<animus:sigil_consumption>                      .setAspects(<aspect:praecantatio>*15 ,<aspect:sanguis>*30        ,<aspect:rattus>*30); #sigil consumption T3
+<animus:sigil_leech>                            .setAspects(<aspect:praecantatio>*10 ,<aspect:sanguis>*15        ,<aspect:desiderium>*20); #sigil leech T2
+<animus:sigil_storm>                            .setAspects(<aspect:praecantatio>*10 ,<aspect:sanguis>*15        ,<aspect:potentia>*50); #sigil storm T2
+<animus:sigil_transposition>                    .setAspects(<aspect:praecantatio>*20 ,<aspect:sanguis>*60        ,<aspect:motus>*40); #sigil acquisition T4
+
+/*
+#######################################################
+
+Astral sorcery
+
+#######################################################
+*/
+
+<astralsorcery:blockmarble>                     .setAspects(<aspect:terra>*4      ,<aspect:ordo>*2); #marble
+<astralsorcery:blockblackmarble>                .setAspects(<aspect:terra>*4        ,<aspect:potentia>*1); #sooty marble
+
+<astralsorcery:itemusabledust>                  .setAspects(<aspect:lux>*2          ,<aspect:sensus>*1); #illumination powder
+<astralsorcery:itemusabledust:1>                .setAspects(<aspect:tenebrae>*10    ,<aspect:potentia>*20); #nocturnal powder
+<astralsorcery:itemcraftingcomponent>           .setAspects(<aspect:aqua>*5         ,<aspect:vitreus>*5); #aquamarine
+<astralsorcery:itemcraftingcomponent:4>         .setAspects(<aspect:praecantatio>*5 ,<aspect:ordo>*10); #resonating gem
+<astralsorcery:itemcraftingcomponent:2>         .setAspects(<aspect:praecantatio>*5 ,<aspect:vitreus>*10        ,<aspect:tenebrae>*5); #stardust
+<astralsorcery:itemcraftingcomponent:1>         .setAspects(<aspect:praecantatio>*5 ,<aspect:metallum>*10       ,<aspect:tenebrae>*5); #starmetal ingot
+<astralsorcery:blockcustomsandore>              .setAspects(<aspect:aqua>*5         ,<aspect:terra>*5           ,<aspect:perditio>*5); #aquamarine ore
+<astralsorcery:blockcustomore:1>                .setAspects(<aspect:praecantatio>*5 ,<aspect:metallum>*10       ,<aspect:terra>*5       ,<aspect:tenebrae>*5); #starmetal ore
+<astralsorcery:blockinfusedwood>                .setAspects(<aspect:herba>*20        ,<aspect:praecantatio>*1); #infused wood
+<astralsorcery:blockinfusedwood:6>              .setAspects(<aspect:herba>*20        ,<aspect:praecantatio>*1); #vibrant infused wood
+
+<astralsorcery:itemcraftingcomponent:3>         .setAspects(<aspect:praecantatio>*10,<aspect:auram>*5           ,<aspect:vitreus>*10); #glass lens and bellow collores lenses
+<astralsorcery:itemcoloredlens>                 .setAspects(<aspect:praecantatio>*10,<aspect:auram>*5           ,<aspect:vitreus>*10    ,<aspect:ignis>*20); #ignition
+<astralsorcery:itemcoloredlens:1>               .setAspects(<aspect:praecantatio>*10,<aspect:auram>*5           ,<aspect:vitreus>*10    ,<aspect:exanimis>*20); #break
+<astralsorcery:itemcoloredlens:2>               .setAspects(<aspect:praecantatio>*10,<aspect:auram>*5           ,<aspect:vitreus>*10    ,<aspect:herba>*20); #growth
+<astralsorcery:itemcoloredlens:3>               .setAspects(<aspect:praecantatio>*10,<aspect:auram>*5           ,<aspect:vitreus>*10    ,<aspect:aversio>*20); #damage (emotional)
+<astralsorcery:itemcoloredlens:4>               .setAspects(<aspect:praecantatio>*10,<aspect:auram>*5           ,<aspect:vitreus>*10    ,<aspect:victus>*20); #regeneration
+<astralsorcery:itemcoloredlens:5>               .setAspects(<aspect:praecantatio>*10,<aspect:auram>*5           ,<aspect:vitreus>*10    ,<aspect:motus>*20); #push
+<astralsorcery:itemcoloredlens:6>               .setAspects(<aspect:praecantatio>*10,<aspect:auram>*5           ,<aspect:vitreus>*10    ,<aspect:spiritus>*20); #spectral
+
+<astralsorcery:itemshiftingstar:*>              .setAspects(<aspect:praecantatio>*20); #shifting star
+
+<astralsorcery:itemrockcrystalsimple>           .setAspects(<aspect:praecantatio>*5 ,<aspect:ordo>*10           ,<aspect:vitreus>*20);                      #rock crystal
+<astralsorcery:blockcustomore>                  .setAspects(<aspect:praecantatio>*5 ,<aspect:ordo>*50           ,<aspect:vitreus>*50    ,<aspect:terra>*5); #rock crystal ore
+<astralsorcery:itemcelestialcrystal>            .setAspects(<aspect:praecantatio>*20,<aspect:ordo>*10           ,<aspect:vitreus>*20    ,<aspect:tenebrae>*10); #celestial crystal
+<astralsorcery:blockcelestialcrystals:4>        .setAspects(<aspect:praecantatio>*50,<aspect:ordo>*50           ,<aspect:vitreus>*100   ,<aspect:tenebrae>*50); #celestial crystal cluster
+<astralsorcery:itemperkgem>                     .setAspects(<aspect:praecantatio>*20,<aspect:ordo>*10           ,<aspect:vitreus>*20    ,<aspect:sensus>*10); #orium gem (blue)
+<astralsorcery:blockgemcrystals:2>              .setAspects(<aspect:praecantatio>*50,<aspect:ordo>*50           ,<aspect:vitreus>*100   ,<aspect:sensus>*50); #^that ore
+<astralsorcery:itemperkgem:1>                   .setAspects(<aspect:praecantatio>*20,<aspect:ordo>*10           ,<aspect:vitreus>*20    ,<aspect:lux>*10); #ilium gem (orange)
+<astralsorcery:blockgemcrystals:3>              .setAspects(<aspect:praecantatio>*50,<aspect:ordo>*50           ,<aspect:vitreus>*100   ,<aspect:lux>*50); #^that ore
+<astralsorcery:itemperkgem:2>                   .setAspects(<aspect:praecantatio>*20,<aspect:ordo>*10           ,<aspect:vitreus>*20    ,<aspect:potentia>*10); #fengarum gem (white)
+<astralsorcery:blockgemcrystals:4>              .setAspects(<aspect:praecantatio>*50,<aspect:ordo>*50           ,<aspect:vitreus>*100   ,<aspect:potentia>*50); #^that ore
+<astralsorcery:blockcollectorcrystal>           .setAspects(<aspect:praecantatio>*30,<aspect:ordo>*50           ,<aspect:vitreus>*40);                          #collector crystal
+<astralsorcery:blockcelestialcollectorcrystal>  .setAspects(<aspect:praecantatio>*100,<aspect:ordo>*100           ,<aspect:vitreus>*200 ,<aspect:tenebrae>*100); #celestial collector crystal
+
+<astralsorcery:blockaltar>                      .setAspects(<aspect:praecantatio>*5 ,<aspect:fabrico>*10        ,<aspect:ordo>*5); #Altar T1
+<astralsorcery:blockaltar:1>                    .setAspects(<aspect:praecantatio>*10,<aspect:fabrico>*20        ,<aspect:ordo>*20); #T2
+<astralsorcery:blockaltar:2>                    .setAspects(<aspect:praecantatio>*50,<aspect:fabrico>*30        ,<aspect:ordo>*50); #T3
+<astralsorcery:blockaltar:3>                    .setAspects(<aspect:praecantatio>*100,<aspect:fabrico>*40       ,<aspect:ordo>*100      ,<aspect:sanguis>*50); #T4
+
+<astralsorcery:blockworldilluminator>           .setAspects(<aspect:lux>*5          ,<aspect:ordo>*5            ,<aspect:vitreus>*10); #Cave illuminator
+<astralsorcery:blockattunementrelay>            .setAspects(<aspect:praecantatio>*10,<aspect:auram>*5           ,<aspect:permutatio>*5); #spectral realy
+<astralsorcery:blocklens>                       .setAspects(<aspect:praecantatio>*10,<aspect:auram>*10          ,<aspect:ordo>*5        ,<aspect:vitreus>*20); #Lens
+<astralsorcery:blockmachine:1>                  .setAspects(<aspect:terra>*5        ,<aspect:fabrico>*5         ,<aspect:machina>*5); #grindstone
+<astralsorcery:itemconstellationpaper>          .setAspects(<aspect:praecantatio>*5 ,<aspect:cognitio>*20       ,<aspect:ordo>*10); #constelation paper
+<astralsorcery:itemknowledgeshare>              .setAspects(<aspect:praecantatio>*5 ,<aspect:cognitio>*20       ,<aspect:ordo>*10); #scroll of written knowledge
+<astralsorcery:blockprism>                      .setAspects(<aspect:praecantatio>*20,<aspect:vitreus>*30        ,<aspect:ordo>*30); #primslens
+<astralsorcery:blockwell>                       .setAspects(<aspect:praecantatio>*5 ,<aspect:aqua>*10           ,<aspect:ordo>*5); #lightwell
+<astralsorcery:blockbore>                       .setAspects(<aspect:praecantatio>*20,<aspect:desiderium>*20     ,<aspect:ordo>*20); #evershifting fountain
+<astralsorcery:blockborehead>                   .setAspects(<aspect:praecantatio>*10,<aspect:desiderium>*20     ,<aspect:ordo>*15); #neromantic prime
+<astralsorcery:blockborehead:1>                 .setAspects(<aspect:praecantatio>*10,<aspect:desiderium>*20     ,<aspect:tenebrae>*15); #fysallidic prime
+<astralsorcery:blockrituallink>                 .setAspects(<aspect:praecantatio>*5 ,<aspect:vitreus>*10        ,<aspect:ordo>*5); #ritual anchor
+
+<astralsorcery:itemsextant>                     .setAspects(<aspect:praecantatio>*5 ,<aspect:sensus>*10         ,<aspect:desiderium>*5); #sextant
+<astralsorcery:itemhandtelescope>               .setAspects(<aspect:praecantatio>*10,<aspect:sensus>*20         ,<aspect:desiderium>*10); #looking glass
+<astralsorcery:blockmachine>                    .setAspects(<aspect:praecantatio>*5 ,<aspect:sensus>*10         ,<aspect:desiderium>*20); #telescope
+<astralsorcery:blockobservatory>                .setAspects(<aspect:praecantatio>*50,<aspect:sensus>*50         ,<aspect:visum>*30      ,<aspect:tenebrae>*20); #observatory
+
+<astralsorcery:blockcelestialgateway>           .setAspects(<aspect:praecantatio>*10,<aspect:alienis>*20        ,<aspect:motus>*50); #celestial gateway
+<astralsorcery:blockstarlightinfuser>           .setAspects(<aspect:praecantatio>*10,<aspect:permutatio>*20     ,<aspect:ordo>*20); #starlight infuser
+<astralsorcery:blockattunementaltar>            .setAspects(<aspect:praecantatio>*10,<aspect:ordo>*10           ,<aspect:desiderium>*20); #attument altar
+<astralsorcery:blockmapdrawingtable>            .setAspects(<aspect:praecantatio>*20,<aspect:sensus>*10         ,<aspect:desiderium>*20 ,<aspect:imperium>*10); #stellar refraction table
+<astralsorcery:blockchalice>                    .setAspects(<aspect:praecantatio>*10,<aspect:tenebrae>*10       ,<aspect:desiderium>*20); #containment chalice
+<astralsorcery:blockritualpedestal>             .setAspects(<aspect:praecantatio>*10,<aspect:ordo>*10           ,<aspect:desiderium>*20); #ritual pedestal
+
+<astralsorcery:itemlinkingtool>                 .setAspects(<aspect:praecantatio>*5 ,<aspect:instrumentum>*10   ,<aspect:vitreus>*10); #linking tool
+<astralsorcery:itemwand>                        .setAspects(<aspect:praecantatio>*5 ,<aspect:instrumentum>*10   ,<aspect:vitreus>*10); #resonating wand
+<astralsorcery:itemilluminationwand>            .setAspects(<aspect:praecantatio>*10,<aspect:lux>*20            ,<aspect:vitreus>*20); #illumination wand
+<astralsorcery:iteminfusedglass>                .setAspects(<aspect:praecantatio>*20,<aspect:auram>*10          ,<aspect:vitreus>*20    ,<aspect:ordo>*20); #infused glass
+<astralsorcery:itemskyresonator>                .setAspects(<aspect:sensus>*10      ,<aspect:ordo>*5            ,<aspect:desiderium>*10); #fosic resonator
+<astralsorcery:itemperkseal>                    .setAspects(<aspect:praecantatio>*10,<aspect:tenebrae>*10       ,<aspect:potentia>*20); #sealing sigil
+
+<astralsorcery:itemenchantmentamulet>           .setAspects(<aspect:praecantatio>*30,<aspect:tenebrae>*10       ,<aspect:vitreus>*10); #resplendent prism
+
+
+/*
+#######################################################
+
+Bloodmagic
+
+#######################################################
+*/
+
+<bloodmagic:slate>                              .setAspects(<aspect:terra>*5        ,<aspect:sanguis>*5); #slate blank
+<bloodmagic:slate:1>                            .setAspects(<aspect:terra>*5        ,<aspect:sanguis>*15); #slate reinforced
+<bloodmagic:slate:2>                            .setAspects(<aspect:terra>*5        ,<aspect:sanguis>*30); #slate imbued
+<bloodmagic:slate:3>                            .setAspects(<aspect:terra>*5        ,<aspect:sanguis>*66); #slate demonic
+<bloodmagic:slate:4>                            .setAspects(<aspect:terra>*5        ,<aspect:sanguis>*100); #slate ethernal
+
+<bloodmagic:blood_shard>                        .setAspects(<aspect:mortuus>*10     ,<aspect:exanimis>*10    ,<aspect:sanguis>*10); #weak blood shard
+<bloodmagic:blood_shard:1>                      .setAspects(<aspect:caeles>*30      ,<aspect:infernum>*50    ,<aspect:sanguis>*20); #demon blood shard
+
+<bloodmagic:activation_crystal>                 .setAspects(<aspect:praecantatio>*10,<aspect:desiderium>*20  ,<aspect:sanguis>*20); #weak activation crystal
+<bloodmagic:activation_crystal:1>               .setAspects(<aspect:praecantatio>*40,<aspect:desiderium>*30  ,<aspect:sanguis>*50); #awekaned activation crystal
+
+<bloodmagic:blood_orb>.withTag({orb: "bloodmagic:weak"})        .setAspects(<aspect:praecantatio>*10  ,<aspect:desiderium>*10   ,<aspect:sanguis>*10); #orb tier 1
+<bloodmagic:blood_orb>.withTag({orb: "bloodmagic:apprentice"})  .setAspects(<aspect:praecantatio>*20  ,<aspect:victus>*10       ,<aspect:sanguis>*25); #orb tier 2
+<bloodmagic:blood_orb>.withTag({orb: "bloodmagic:magician"})    .setAspects(<aspect:praecantatio>*30  ,<aspect:metallum>*50     ,<aspect:sanguis>*50); #orb tier 3
+<bloodmagic:blood_orb>.withTag({orb: "bloodmagic:master"})      .setAspects(<aspect:praecantatio>*40  ,<aspect:mortuus>*20      ,<aspect:sanguis>*80); #orb tier 4
+<bloodmagic:blood_orb>.withTag({orb: "bloodmagic:archmage"})    .setAspects(<aspect:praecantatio>*50  ,<aspect:ordo>*100        ,<aspect:sanguis>*100); #orb tier 5
+<bloodmagic:blood_orb>.withTag({orb: "bloodmagic:transcendent"}).setAspects(<aspect:praecantatio>*100 ,<aspect:caeles>*100      ,<aspect:sanguis>*300); #orb tier 6
+
+<bloodmagic:soul_snare>                         .setAspects(<aspect:vinculum>*3     ,<aspect:imperium>*3     ,<aspect:ventus>*1); #rudimentary snare
+<bloodmagic:arcane_ashes:*>                     .setAspects(<aspect:potentia>*10    ,<aspect:ignis>*10       ,<aspect:exitium>*5); #arcane ashes
+
+<bloodmagic:soul_forge>                         .setAspects(<aspect:instrumentum>*20,<aspect:spiritus>*30    ,<aspect:praecantatio>*15); #rudimentary snare
+<bloodmagic:demon_pylon>                        .setAspects(<aspect:infernum>*30    ,<aspect:spiritus>*20    ,<aspect:desiderium>*20); #rudimentary snare
+<bloodmagic:demon_crucible>                     .setAspects(<aspect:infernum>*30    ,<aspect:spiritus>*20    ,<aspect:fluctus>*15); #rudimentary snare
+<bloodmagic:demon_crystallizer>                 .setAspects(<aspect:infernum>*30    ,<aspect:spiritus>*20    ,<aspect:fluctus>*15); #rudimentary snare
+<bloodmagic:alchemy_table>                      .setAspects(<aspect:alkimia>*25     ,<aspect:ordo>*20        ,<aspect:praecantatio>*20); #rudimentary snare
+<bloodmagic:altar>                              .setAspects(<aspect:terra>*15       ,<aspect:praecantatio>*10,<aspect:aversio>*30); #rudimentary snare
+
+<bloodmagic:monster_soul>                       .setAspects(<aspect:spiritus>*2     ,<aspect:infernum>*2);                       #demonic will
+<bloodmagic:monster_soul:1>                     .setAspects(<aspect:spiritus>*2     ,<aspect:infernum>*2     ,<aspect:alkimia>*1); #corrosive
+<bloodmagic:monster_soul:2>                     .setAspects(<aspect:spiritus>*2     ,<aspect:infernum>*2     ,<aspect:exitium>*1); #destructive
+<bloodmagic:monster_soul:3>                     .setAspects(<aspect:spiritus>*2     ,<aspect:infernum>*2     ,<aspect:mortuus>*1); #vengeful
+<bloodmagic:monster_soul:4>                     .setAspects(<aspect:spiritus>*2     ,<aspect:infernum>*2     ,<aspect:alienis>*1); #steadfast
+
+<bloodmagic:item_demon_crystal>                 .setAspects(<aspect:spiritus>*30    ,<aspect:infernum>*25);                       #demonic will crystal
+<bloodmagic:item_demon_crystal:1>               .setAspects(<aspect:spiritus>*30    ,<aspect:infernum>*25    ,<aspect:alkimia>*20); #corrosive
+<bloodmagic:item_demon_crystal:2>               .setAspects(<aspect:spiritus>*30    ,<aspect:infernum>*25    ,<aspect:exitium>*20); #destructive
+<bloodmagic:item_demon_crystal:3>               .setAspects(<aspect:spiritus>*30    ,<aspect:infernum>*25    ,<aspect:mortuus>*20); #vengeful
+<bloodmagic:item_demon_crystal:4>               .setAspects(<aspect:spiritus>*30    ,<aspect:infernum>*25    ,<aspect:alienis>*20); #steadfast
+
+<bloodmagic:sentient_sword>                     .setAspects(<aspect:spiritus>*20    ,<aspect:aversio>*30);
+<bloodmagic:sentient_bow>                       .setAspects(<aspect:spiritus>*20    ,<aspect:aversio>*15     ,<aspect:ventus>*15);
+<bloodmagic:sentient_axe>                       .setAspects(<aspect:spiritus>*20    ,<aspect:instrumentum>*20);
+<bloodmagic:sentient_pickaxe>                   .setAspects(<aspect:spiritus>*20    ,<aspect:instrumentum>*20);
+<bloodmagic:sentient_shovel>                    .setAspects(<aspect:spiritus>*20    ,<aspect:instrumentum>*20);
+
+<bloodmagic:sacrificial_dagger>                 .setAspects(<aspect:alienis>*5      ,<aspect:aversio>*5      ,<aspect:mortuus>*10);
+<bloodmagic:dagger_of_sacrifice>                .setAspects(<aspect:sanguis>*15     ,<aspect:instrumentum>*10,<aspect:aversio>*10);
+
+<bloodmagic:component:8>                        .setAspects(<aspect:praecantatio>*5  ,<aspect:aqua>*10); #reagent binding
+<bloodmagic:sigil_whirlwind>                    .setAspects(<aspect:praecantatio>*5  ,<aspect:sanguis>*5   ,<aspect:aer>*20); #sigil wirldwind
+<bloodmagic:component:29>                       .setAspects(<aspect:praecantatio>*5  ,<aspect:alkimia>*5  ,<aspect:potentia>*10); #simple power catalyst
+<bloodmagic:component:28>                       .setAspects(<aspect:praecantatio>*5  ,<aspect:alkimia>*5  ,<aspect:sensus>*10); #simple lengthening catalyst
+
+# TIERED REAGENTS AND SIGILS
+# Tier 1
+
+<bloodmagic:component>                          .setAspects(<aspect:praecantatio>*5  ,<aspect:aqua>*10); #reagent water
+<bloodmagic:component:1>                        .setAspects(<aspect:praecantatio>*5  ,<aspect:ignis>*10); #reagent lava
+
+<bloodmagic:sigil_water>                        .setAspects(<aspect:praecantatio>*5  ,<aspect:sanguis>*5     ,<aspect:aqua>*10); #sigil water
+<bloodmagic:sigil_lava>                         .setAspects(<aspect:praecantatio>*5  ,<aspect:sanguis>*5     ,<aspect:ignis>*10); #sigil lava
+<bloodmagic:sigil_divination>                   .setAspects(<aspect:praecantatio>*5  ,<aspect:sanguis>*5     ,<aspect:cognitio>*10); #sigil divination
+
+#Tier 2
+
+<bloodmagic:component:5>                        .setAspects(<aspect:praecantatio>*10  ,<aspect:herba>*20); #reagent growth
+<bloodmagic:component:31>                       .setAspects(<aspect:praecantatio>*10  ,<aspect:praecantatio>*20); #reagent elasticy
+<bloodmagic:component:2>                        .setAspects(<aspect:praecantatio>*10  ,<aspect:volatus>*20); #reagent air
+<bloodmagic:component:7>                        .setAspects(<aspect:praecantatio>*10  ,<aspect:sensus>*20); #reagent sight
+<bloodmagic:component:3>                        .setAspects(<aspect:praecantatio>*10  ,<aspect:exitium>*20); #reagent mining
+<bloodmagic:component:32>                       .setAspects(<aspect:praecantatio>*10  ,<aspect:gelum>*20); #reagent frost
+<bloodmagic:component:4>                        .setAspects(<aspect:praecantatio>*10  ,<aspect:vacuos>*20); #reagent void
+
+<bloodmagic:sigil_green_grove>                  .setAspects(<aspect:praecantatio>*10  ,<aspect:sanguis>*15   ,<aspect:herba>*20); #sigil growth
+<bloodmagic:sigil_bounce>                       .setAspects(<aspect:praecantatio>*10  ,<aspect:sanguis>*15   ,<aspect:praemunio>*20); #sigil elasticy
+<bloodmagic:sigil_air>                          .setAspects(<aspect:praecantatio>*10  ,<aspect:sanguis>*15   ,<aspect:volatus>*20); #sigil air
+<bloodmagic:sigil_seer>                         .setAspects(<aspect:praecantatio>*10  ,<aspect:sanguis>*15   ,<aspect:sensus>*20); #sigil sight
+<bloodmagic:sigil_fast_miner>                   .setAspects(<aspect:praecantatio>*10  ,<aspect:sanguis>*15   ,<aspect:exitium>*20); #sigil mining
+<bloodmagic:sigil_frost>                        .setAspects(<aspect:praecantatio>*10  ,<aspect:sanguis>*15   ,<aspect:gelum>*20); #sigil frost
+<bloodmagic:sigil_void>                         .setAspects(<aspect:praecantatio>*10  ,<aspect:sanguis>*15   ,<aspect:vacuos>*20); #sigil void
+
+#Tier 3
+
+<bloodmagic:component:12>                       .setAspects(<aspect:praecantatio>*15  ,<aspect:metallum>*30); #reagent magnetism
+<bloodmagic:component:27>                       .setAspects(<aspect:praecantatio>*15  ,<aspect:vinculum>*30); #reagent holding
+<bloodmagic:component:11>                       .setAspects(<aspect:praecantatio>*15  ,<aspect:lux>*30); #reagent blood lamp
+<bloodmagic:component:30>                       .setAspects(<aspect:praecantatio>*15  ,<aspect:bestia>*30); #reagent claw
+<bloodmagic:component:6>                        .setAspects(<aspect:praecantatio>*15  ,<aspect:aer>*10,<aspect:ignis>*10,<aspect:terra>*10,<aspect:aqua>*10); #reagent elemental affinity
+
+<bloodmagic:sigil_magnetism>                    .setAspects(<aspect:praecantatio>*15  ,<aspect:sanguis>*30   ,<aspect:metallum>*30); #sigil magnetism
+<bloodmagic:sigil_holding>                      .setAspects(<aspect:praecantatio>*15  ,<aspect:sanguis>*30   ,<aspect:vinculum>*30); #sigil holding
+<bloodmagic:sigil_blood_light>                  .setAspects(<aspect:praecantatio>*15  ,<aspect:sanguis>*30   ,<aspect:vacuos>*30); #sigil blood lamp
+<bloodmagic:sigil_claw>                         .setAspects(<aspect:praecantatio>*15  ,<aspect:sanguis>*30   ,<aspect:bestia>*30); #sigil claw
+<bloodmagic:sigil_elemental_affinity>           .setAspects(<aspect:praecantatio>*15  ,<aspect:sanguis>*30   ,<aspect:aer>*10,<aspect:ignis>*10,<aspect:terra>*10,<aspect:aqua>*10); #sigil elemental affinity
+
+#Tier 4
+
+<bloodmagic:component:18>                       .setAspects(<aspect:praecantatio>*20  ,<aspect:permutatio>*40); #reagent transposition
+<bloodmagic:component:17>                       .setAspects(<aspect:praecantatio>*20  ,<aspect:alienis>*40); #reagent teleposition
+<bloodmagic:component:9>                        .setAspects(<aspect:praecantatio>*20  ,<aspect:perditio>*40); #reagent supression
+<bloodmagic:component:15>                       .setAspects(<aspect:praecantatio>*20  ,<aspect:spiritus>*40); #reagent phantom bridge
+<bloodmagic:component:13>                       .setAspects(<aspect:praecantatio>*20  ,<aspect:ventus>*40); #reagent haste
+<bloodmagic:component:16>                       .setAspects(<aspect:praecantatio>*20  ,<aspect:tenebrae>*40); #reagent severance
+<bloodmagic:component:14>                       .setAspects(<aspect:praecantatio>*20  ,<aspect:ordo>*40); #reagent compression
+
+<bloodmagic:sigil_transposition>                .setAspects(<aspect:praecantatio>*20  ,<aspect:sanguis>*60   ,<aspect:permutatio>*40); #sigil transposition
+<bloodmagic:sigil_teleposition>                 .setAspects(<aspect:praecantatio>*20  ,<aspect:sanguis>*60   ,<aspect:alienis>*40); #sigil teleposiotion
+<bloodmagic:sigil_suppression>                  .setAspects(<aspect:praecantatio>*20  ,<aspect:sanguis>*60   ,<aspect:perditio>*40); #sigil supression
+<bloodmagic:sigil_phantom_bridge>               .setAspects(<aspect:praecantatio>*20  ,<aspect:sanguis>*60   ,<aspect:spiritus>*40); #sigil phantom bridge
+<bloodmagic:sigil_haste>                        .setAspects(<aspect:praecantatio>*20  ,<aspect:sanguis>*60   ,<aspect:ventus>*40); #sigil haste
+<bloodmagic:sigil_ender_severance>              .setAspects(<aspect:praecantatio>*20  ,<aspect:sanguis>*60   ,<aspect:tenebrae>*40); #sigil severance
+<bloodmagic:sigil_compression>                  .setAspects(<aspect:praecantatio>*20  ,<aspect:sanguis>*60   ,<aspect:ordo>*40); #sigil compression
+
+/*
+#######################################################
+
+Botania
+
+#######################################################
+*/
+
+<botania:manaresource>                          .setAspects(<aspect:metallum>*10  ,<aspect:mana>*5); #manasteel
+<botania:manaresource:1>                        .setAspects(<aspect:alienis>*10   ,<aspect:motus>*5           ,<aspect:mana>*10); #manapearl
+<botania:manaresource:2>                        .setAspects(<aspect:vitreus>*15   ,<aspect:desiderium>*15     ,<aspect:mana>*10); #manadiamond
+<botania:manaresource:4>                        .setAspects(<aspect:terra>*20     ,<aspect:praecantatio>*20   ,<aspect:mana>*10         ,<aspect:metallum>*10); #terrasteel
+<botania:manaresource:7>                        .setAspects(<aspect:alienis>*5    ,<aspect:metallum>*10       ,<aspect:mana>*5); #elementium
+<botania:manaresource:8>                        .setAspects(<aspect:alienis>*20   ,<aspect:mythus>*5          ,<aspect:mana>*10); #pixie dust
+<botania:manaresource:9>                        .setAspects(<aspect:alienis>*10   ,<aspect:vitreus>*15        ,<aspect:mana>*10         ,<aspect:desiderium>*15); #dragon gem
+<botania:manaresource:16>                       .setAspects(<aspect:bestia>*5     ,<aspect:fabrico>*2         ,<aspect:mana>*2); #mana string
+<botania:manaresource:23>                       .setAspects(<aspect:potentia>*5   ,<aspect:mana>*5); #mana powder
+<botania:manaresource:22>                       .setAspects(<aspect:praemunio>*10 ,<aspect:mana>*5); #manaweave cloth
+<botania:manabottle:*>                          .setAspects(<aspect:mana>*10); #mana bottle
+<botania:managlass>                             .setAspects(<aspect:vitreus>*5    ,<aspect:mana>*2); #mana glass
+<botania:monocle>                               .setAspects(<aspect:sensus>*10    ,<aspect:visum>*20          ,<aspect:mana>*6); #monocle
+<botania:blacklotus>                            .setAspects(<aspect:alienis>*10   ,<aspect:ordo>*10           ,<aspect:mana>*15); #monocle
+<botania:blacklotus:1>                          .setAspects(<aspect:alienis>*20   ,<aspect:ordo>*20           ,<aspect:mana>*50); #monocle
+
+<botania:rune:3>                                .setAspects(<aspect:terra>*5      ,<aspect:aer>*25            ,<aspect:mana>*5); #rune air
+<botania:rune:2>                                .setAspects(<aspect:terra>*30     ,<aspect:mana>*5); #rune earth
+<botania:rune:1>                                .setAspects(<aspect:terra>*5      ,<aspect:ignis>*25          ,<aspect:mana>*5); #rune fire
+<botania:rune>                                  .setAspects(<aspect:terra>*5      ,<aspect:aqua>*25           ,<aspect:mana>*5); #rune water
+
+<botania:rune:7>                                .setAspects(<aspect:terra>*5      ,<aspect:gelum>*25          ,<aspect:mana>*10); #rune winter
+<botania:rune:6>                                .setAspects(<aspect:terra>*5      ,<aspect:mortuus>*25        ,<aspect:mana>*10); #rune autumn
+<botania:rune:5>                                .setAspects(<aspect:terra>*5      ,<aspect:victus>*25         ,<aspect:mana>*10); #rune summer
+<botania:rune:4>                                .setAspects(<aspect:terra>*5      ,<aspect:herba>*25          ,<aspect:mana>*10); #rune spring
+<botania:rune:8>                                .setAspects(<aspect:terra>*5      ,<aspect:auram>*25          ,<aspect:mana>*15); #rune of mana
+
+<botania:rune:15>                               .setAspects(<aspect:terra>*5      ,<aspect:desiderium>*20     ,<aspect:mythus>*30       ,<aspect:mana>*15); #rune pride
+<botania:rune:14>                               .setAspects(<aspect:terra>*5      ,<aspect:desiderium>*20     ,<aspect:spiritus>*30     ,<aspect:mana>*15); #rune envy
+<botania:rune:13>                               .setAspects(<aspect:terra>*5      ,<aspect:desiderium>*20     ,<aspect:aversio>*30      ,<aspect:mana>*15); #rune wrath
+<botania:rune:12>                               .setAspects(<aspect:terra>*5      ,<aspect:desiderium>*20     ,<aspect:imperium>*30     ,<aspect:mana>*15); #rune sloth
+<botania:rune:11>                               .setAspects(<aspect:terra>*5      ,<aspect:desiderium>*20     ,<aspect:humanus>*30      ,<aspect:mana>*15); #rune greed
+<botania:rune:10>                               .setAspects(<aspect:terra>*5      ,<aspect:desiderium>*20     ,<aspect:vacuos>*30       ,<aspect:mana>*15); #rune gluttony
+<botania:rune:9>                                .setAspects(<aspect:terra>*5      ,<aspect:desiderium>*20     ,<aspect:fluctus>*30      ,<aspect:mana>*15); #rune lust
+
+/*
+#######################################################
+
+Chisell/Quark - general stones
+
+#######################################################
+*/
+
+<chisel:basalt2:7>                              .setAspects(<aspect:terra>*4      ,<aspect:tenebrae>*2); #basalt
+<chisel:marble2:7>                              .setAspects(<aspect:terra>*4      ,<aspect:ordo>*2); #marble
+<quark:jasper>                                  .setAspects(<aspect:terra>*4      ,<aspect:ignis>*2); #jasper
+
+<quark:black_ash>                               .setAspects(<aspect:perditio>*4      ,<aspect:tenebrae>*2); #wither ash
+
+/*
+#######################################################
+
+Draconic evolution
+
+#######################################################
+*/
+
+<draconicevolution:dragon_heart>                .setAspects(<aspect:draco>*100    ,<aspect:praecantatio>*50   ,<aspect:spiritus>*30     ,<aspect:victus>*100); #dragon heart
+
+/*
+#######################################################
+
+Ice and fire
+
+#######################################################
+*/
+
+#General
+
+<iceandfire:manuscript>                        .setAspects(<aspect:cognitio>*20); #manuscript
+<iceandfire:witherbone>                        .setAspects(<aspect:mortuus>*10      ,<aspect:infernum>*10     ,<aspect:tenebrae>*5       ,<aspect:perditio>*5); #wither bone
+<iceandfire:myrmex_stinger>                    .setAspects(<aspect:mythus>*5        ,<aspect:aversio>*6       ,<aspect:alkimia>*5);
+
+<minecraft:spawn_egg>.withTag({EntityTag: {id: "iceandfire:myrmex_worker"}})
+                                                .setAspects(<aspect:mythus>*10       ,<aspect:bestia>*10      ,<aspect:fabrico>*5);
+<entity:iceandfire:myrmex_worker>               .setAspects(<aspect:mythus>*10       ,<aspect:bestia>*10      ,<aspect:fabrico>*5);
+<minecraft:spawn_egg>.withTag({EntityTag: {id: "iceandfire:myrmex_soldier"}})
+                                                .setAspects(<aspect:mythus>*15       ,<aspect:bestia>*15      ,<aspect:aversio>*20);
+<entity:iceandfire:myrmex_soldier>              .setAspects(<aspect:mythus>*15       ,<aspect:bestia>*15      ,<aspect:aversio>*20);
+<minecraft:spawn_egg>.withTag({EntityTag: {id: "iceandfire:myrmex_sentinel"}})
+                                                .setAspects(<aspect:mythus>*20       ,<aspect:bestia>*20      ,<aspect:sensus>*50);
+<entity:iceandfire:myrmex_sentinel>             .setAspects(<aspect:mythus>*20       ,<aspect:bestia>*20      ,<aspect:sensus>*50);
+<minecraft:spawn_egg>.withTag({EntityTag: {id: "iceandfire:myrmex_royal"}})
+                                                .setAspects(<aspect:mythus>*30       ,<aspect:bestia>*30      ,<aspect:volatus>*50);
+<entity:iceandfire:myrmex_royal>                .setAspects(<aspect:mythus>*30       ,<aspect:bestia>*30      ,<aspect:volatus>*50);
+/*
+<minecraft:spawn_egg>.withTag({EntityTag: {id: "iceandfire:myrmex_queen"}})
+                                                .setAspects(<aspect:mythus>*300      ,<aspect:bestia>*300       ,<aspect:desiderium>*200);
+<entity:iceandfire:myrmex_queen>                .setAspects(<aspect:mythus>*300      ,<aspect:bestia>*300       ,<aspect:desiderium>*200);
+*/
+
+#Dragons general
+
+<iceandfire:dragonbone>                         .setAspects(<aspect:draco>*5      ,<aspect:praecantatio>*2    ,<aspect:mortuus>*5); #dragon bone
+<iceandfire:dragon_meal>                        .setAspects(<aspect:victus>*20    ,<aspect:bestia>*10         ,<aspect:mortuus>*20); #dragon meal
+
+#Fire
+/*
+<minecraft:spawn_egg>.withTag({EntityTag: {id: "iceandfire:firedragon"}})
+                                                .setAspects(<aspect:draco>*500    ,<aspect:praecantatio>*500  ,<aspect:desiderium>*500  ,<aspect:victus>*500    ,<aspect:ignis>*500);
+<entity:iceandfire:firedragon>                  .setAspects(<aspect:draco>*500    ,<aspect:praecantatio>*500  ,<aspect:desiderium>*500  ,<aspect:victus>*500    ,<aspect:ignis>*500);
+*/
+<iceandfire:fire_dragon_heart>                  .setAspects(<aspect:draco>*100    ,<aspect:praecantatio>*50   ,<aspect:spiritus>*30     ,<aspect:victus>*100    ,<aspect:ignis>*50); #heart
+<iceandfire:fire_dragon_flesh>                  .setAspects(<aspect:draco>*10     ,<aspect:victus>*10         ,<aspect:mortuus>*20      ,<aspect:ignis>*20); #flesh
+<iceandfire:fire_dragon_blood>                  .setAspects(<aspect:draco>*5      ,<aspect:praecantatio>*10   ,<aspect:alkimia>*10      ,<aspect:ignis>*10); #blood
+<iceandfire:dragon_skull>                       .setAspects(<aspect:draco>*25     ,<aspect:spiritus>*10       ,<aspect:mortuus>*10      ,<aspect:ignis>*30); #skull
+<iceandfire:dragonscales_red>                   .setAspects(<aspect:draco>*5      ,<aspect:praemunio>*7       ,<aspect:infernum>*10     ,<aspect:ignis>*10); #scales red
+<iceandfire:dragonscales_bronze>                .setAspects(<aspect:draco>*5      ,<aspect:praemunio>*7       ,<aspect:desiderium>*10   ,<aspect:ignis>*10); #scales bronze
+<iceandfire:dragonscales_green>                 .setAspects(<aspect:draco>*5      ,<aspect:praemunio>*7       ,<aspect:visum>*10        ,<aspect:ignis>*10); #scales green
+<iceandfire:dragonscales_gray>                  .setAspects(<aspect:draco>*5      ,<aspect:praemunio>*7       ,<aspect:exitium>*10      ,<aspect:ignis>*10); #scales gray
+<iceandfire:dragonegg_red>                      .setAspects(<aspect:draco>*100    ,<aspect:praecantatio>*10   ,<aspect:infernum>*10     ,<aspect:ignis>*10); #egg red
+<iceandfire:dragonegg_bronze>                   .setAspects(<aspect:draco>*100    ,<aspect:praecantatio>*10   ,<aspect:desiderium>*10   ,<aspect:ignis>*10); #egg bronze
+<iceandfire:dragonegg_green>                    .setAspects(<aspect:draco>*100    ,<aspect:praecantatio>*10   ,<aspect:visum>*10        ,<aspect:ignis>*10); #egg green
+<iceandfire:dragonegg_gray>                     .setAspects(<aspect:draco>*100    ,<aspect:praecantatio>*10   ,<aspect:exitium>*10      ,<aspect:ignis>*10); #egg gray
+<iceandfire:dragonsteel_fire_ingot>             .setAspects(<aspect:draco>*25     ,<aspect:metallum>*20       ,<aspect:desiderium>*40   ,<aspect:ignis>*50); #dragonsteel ingot
+<iceandfire:fire_lily>                          .setAspects(<aspect:draco>*5      ,<aspect:praecantatio>*2    ,<aspect:herba>*5         ,<aspect:ignis>*5); #lily
+<iceandfire:fire_stew>                          .setAspects(<aspect:draco>*5      ,<aspect:praecantatio>*5    ,<aspect:ignis>*20); #lily mixture
+
+#Ice
+/*
+<minecraft:spawn_egg>.withTag({EntityTag: {id: "iceandfire:icedragon"}})
+                                                .setAspects(<aspect:draco>*500    ,<aspect:praecantatio>*500  ,<aspect:desiderium>*500  ,<aspect:victus>*500    ,<aspect:gelum>*500);
+<entity:iceandfire:icedragon>                   .setAspects(<aspect:draco>*500    ,<aspect:praecantatio>*500  ,<aspect:desiderium>*500  ,<aspect:victus>*500    ,<aspect:gelum>*500);
+*/
+<iceandfire:ice_dragon_heart>                   .setAspects(<aspect:draco>*100    ,<aspect:praecantatio>*50   ,<aspect:spiritus>*30     ,<aspect:victus>*100    ,<aspect:gelum>*50); #heart
+<iceandfire:ice_dragon_flesh>                   .setAspects(<aspect:draco>*10     ,<aspect:victus>*10         ,<aspect:mortuus>*20      ,<aspect:gelum>*20); #flesh
+<iceandfire:ice_dragon_blood>                   .setAspects(<aspect:draco>*5      ,<aspect:praecantatio>*10   ,<aspect:alkimia>*10      ,<aspect:gelum>*10); #blood
+<iceandfire:dragon_skull:1>                     .setAspects(<aspect:draco>*25     ,<aspect:spiritus>*10       ,<aspect:mortuus>*10      ,<aspect:gelum>*30); #skull
+<iceandfire:dragonscales_sapphire>              .setAspects(<aspect:draco>*5      ,<aspect:praemunio>*15      ,<aspect:instrumentum>*10 ,<aspect:gelum>*10); #scales sapphire
+<iceandfire:dragonscales_blue>                  .setAspects(<aspect:draco>*5      ,<aspect:praemunio>*15      ,<aspect:vitreus>*10      ,<aspect:gelum>*10); #scales blue
+<iceandfire:dragonscales_white>                 .setAspects(<aspect:draco>*5      ,<aspect:praemunio>*15      ,<aspect:volatus>*10      ,<aspect:gelum>*10); #scales white
+<iceandfire:dragonscales_silver>                .setAspects(<aspect:draco>*5      ,<aspect:praemunio>*15      ,<aspect:fluctus>*10      ,<aspect:gelum>*10); #scales silver
+<iceandfire:dragonegg_sapphire>                 .setAspects(<aspect:draco>*100    ,<aspect:praecantatio>*10   ,<aspect:instrumentum>*10 ,<aspect:gelum>*10); #egg sapphire
+<iceandfire:dragonegg_blue>                     .setAspects(<aspect:draco>*100    ,<aspect:praecantatio>*10   ,<aspect:vitreus>*10      ,<aspect:gelum>*10); #egg blue
+<iceandfire:dragonegg_white>                    .setAspects(<aspect:draco>*100    ,<aspect:praecantatio>*10   ,<aspect:volatus>*10      ,<aspect:gelum>*10); #egg white
+<iceandfire:dragonegg_silver>                   .setAspects(<aspect:draco>*100    ,<aspect:praecantatio>*10   ,<aspect:fluctus>*10      ,<aspect:gelum>*10); #egg silver
+<iceandfire:dragonsteel_ice_ingot>              .setAspects(<aspect:draco>*25     ,<aspect:metallum>*20       ,<aspect:desiderium>*40   ,<aspect:gelum>*50); #dragonsteel ingot
+<iceandfire:frost_lily>                         .setAspects(<aspect:draco>*5      ,<aspect:praecantatio>*2    ,<aspect:herba>*5         ,<aspect:gelum>*5); #lily
+<iceandfire:frost_stew>                         .setAspects(<aspect:draco>*5      ,<aspect:praecantatio>*5    ,<aspect:gelum>*20); #lily mixture
+
+#Ocean creatures
+/*
+<minecraft:spawn_egg>.withTag({EntityTag: {id: "iceandfire:seaserpent"}})
+                                                .setAspects(<aspect:draco>*100    ,<aspect:aqua>*300         ,<aspect:mythus>*300);
+<entity:iceandfire:seaserpent>                  .setAspects(<aspect:draco>*100    ,<aspect:aqua>*300         ,<aspect:mythus>*300);
+*/
+<iceandfire:sea_serpent_fang>                   .setAspects(<aspect:draco>*5      ,<aspect:aversio>*10        ,<aspect:aqua>*10         ,<aspect:mythus>*5); #fang
+<iceandfire:sea_serpent_scales_teal>            .setAspects(<aspect:draco>*5      ,<aspect:praemunio>*10      ,<aspect:aqua>*10         ,<aspect:alkimia>*5       ,<aspect:mythus>*10); #scale teal
+<iceandfire:sea_serpent_scales_deepblue>        .setAspects(<aspect:draco>*5      ,<aspect:praemunio>*10      ,<aspect:aqua>*10         ,<aspect:instrumentum>*5  ,<aspect:mythus>*10); #scale deepblue
+<iceandfire:sea_serpent_scales_bronze>          .setAspects(<aspect:draco>*5      ,<aspect:praemunio>*10      ,<aspect:aqua>*10         ,<aspect:sonus>*5         ,<aspect:mythus>*10); #scale bronze
+<iceandfire:sea_serpent_scales_blue>            .setAspects(<aspect:draco>*5      ,<aspect:praemunio>*10      ,<aspect:aqua>*10         ,<aspect:vitreus>*5       ,<aspect:mythus>*10); #scale blue
+<iceandfire:sea_serpent_scales_green>           .setAspects(<aspect:draco>*5      ,<aspect:praemunio>*10      ,<aspect:aqua>*10         ,<aspect:visum>*5         ,<aspect:mythus>*10); #scale green
+<iceandfire:sea_serpent_scales_purple>          .setAspects(<aspect:draco>*5      ,<aspect:praemunio>*10      ,<aspect:aqua>*10         ,<aspect:praecantatio>*5  ,<aspect:mythus>*10); #scale purple
+<iceandfire:sea_serpent_scales_red>             .setAspects(<aspect:draco>*5      ,<aspect:praemunio>*10      ,<aspect:aqua>*10         ,<aspect:victus>*5        ,<aspect:mythus>*10); #scale red
+<iceandfire:seaserpent_skull>                   .setAspects(<aspect:draco>*10     ,<aspect:spiritus>*20       ,<aspect:aqua>*20         ,<aspect:mythus>*50); #skull
+
+<minecraft:spawn_egg>.withTag({EntityTag: {id: "iceandfire:siren"}})
+                                                .setAspects(<aspect:sonus>*50     ,<aspect:imperium>*30       ,<aspect:aqua>*50         ,<aspect:mythus>*30);
+<entity:iceandfire:siren>                       .setAspects(<aspect:sonus>*50     ,<aspect:imperium>*30       ,<aspect:aqua>*50         ,<aspect:mythus>*30);
+<minecraft:spawn_egg>.withTag({EntityTag: {id: "iceandfire:hippocampus"}})
+                                                .setAspects(<aspect:motus>*20     ,<aspect:mythus>*20         ,<aspect:aqua>*50);
+<entity:iceandfire:hippocampus>                 .setAspects(<aspect:motus>*20     ,<aspect:mythus>*20         ,<aspect:aqua>*50);
+<iceandfire:shiny_scales>                       .setAspects(<aspect:desiderium>*20,<aspect:praemunio>*5       ,<aspect:aqua>*10         ,<aspect:mythus>*2); #shiny scales
+<iceandfire:siren_tear>                         .setAspects(<aspect:sonus>*100    ,<aspect:imperium>*50       ,<aspect:aqua>*50         ,<aspect:mythus>*50); #siren 
+<iceandfire:hippocampus_fin>                    .setAspects(<aspect:motus>*100    ,<aspect:mythus>*50         ,<aspect:aqua>*50); #hippocampus 
+
+#Beach creatures
+
+<minecraft:spawn_egg>.withTag({EntityTag: {id: "iceandfire:gorgon"}})
+                                                .setAspects(<aspect:mythus>*200   ,<aspect:praecantatio>*100  ,<aspect:exanimis>*200    ,<aspect:humanus>*400);
+<entity:iceandfire:gorgon>                      .setAspects(<aspect:mythus>*200   ,<aspect:praecantatio>*100  ,<aspect:exanimis>*200    ,<aspect:humanus>*400);
+<iceandfire:gorgon_head>                        .setAspects(<aspect:mythus>*50    ,<aspect:mortuus>*50        ,<aspect:exanimis>*40     ,<aspect:humanus>*50); #gorgon
+
+<minecraft:spawn_egg>.withTag({EntityTag: {id: "iceandfire:cyclops"}})
+                                                .setAspects(<aspect:mythus>*100   ,<aspect:visum>*100         ,<aspect:potentia>*200);
+<entity:iceandfire:cyclops>                     .setAspects(<aspect:mythus>*400   ,<aspect:visum>*100         ,<aspect:potentia>*200);
+<iceandfire:cyclops_eye>                        .setAspects(<aspect:mythus>*20    ,<aspect:visum>*30          ,<aspect:mortuus>*20      ,<aspect:bestia>*50); #cyclop
+<iceandfire:cyclops_skull>                      .setAspects(<aspect:mythus>*30    ,<aspect:spiritus>*20       ,<aspect:potentia>*20     ,<aspect:terra>*50); 
+
+#Underground
+
+<minecraft:spawn_egg>.withTag({EntityTag: {id: "iceandfire:if_troll"}})
+                                                .setAspects(<aspect:mythus>*50    ,<aspect:tenebrae>*50       ,<aspect:terra>*100);
+<entity:iceandfire:if_troll>                    .setAspects(<aspect:mythus>*50    ,<aspect:tenebrae>*50       ,<aspect:terra>*100);
+<iceandfire:troll_skull>                        .setAspects(<aspect:mythus>*20    ,<aspect:spiritus>*20       ,<aspect:tenebrae>*20     ,<aspect:terra>*30); #troll skull
+<iceandfire:troll_leather_frost>                .setAspects(<aspect:mythus>*10    ,<aspect:praemunio>*10      ,<aspect:tenebrae>*10     ,<aspect:gelum>*15); #leather frost
+<iceandfire:troll_leather_mountain>             .setAspects(<aspect:mythus>*10    ,<aspect:praemunio>*10      ,<aspect:tenebrae>*10     ,<aspect:terra>*15); #leather mountain
+<iceandfire:troll_leather_forest>               .setAspects(<aspect:mythus>*10    ,<aspect:praemunio>*10      ,<aspect:tenebrae>*10     ,<aspect:herba>*15); #leather forest
+<iceandfire:troll_weapon.trunk_frost>           .setAspects(<aspect:mythus>*10    ,<aspect:aversio>*20        ,<aspect:tenebrae>*10     ,<aspect:praecantatio>*10); #troll weapons
+<iceandfire:troll_weapon.hammer>                .setAspects(<aspect:mythus>*10    ,<aspect:aversio>*20        ,<aspect:tenebrae>*10     ,<aspect:praecantatio>*10); 
+<iceandfire:troll_weapon.column_forest>         .setAspects(<aspect:mythus>*10    ,<aspect:aversio>*20        ,<aspect:tenebrae>*10     ,<aspect:praecantatio>*10); 
+<iceandfire:troll_weapon.column_frost>          .setAspects(<aspect:mythus>*10    ,<aspect:aversio>*20        ,<aspect:tenebrae>*10     ,<aspect:praecantatio>*10); 
+<iceandfire:troll_weapon.trunk>                 .setAspects(<aspect:mythus>*10    ,<aspect:aversio>*20        ,<aspect:tenebrae>*10     ,<aspect:praecantatio>*10); 
+<iceandfire:troll_weapon.axe>                   .setAspects(<aspect:mythus>*10    ,<aspect:aversio>*20        ,<aspect:tenebrae>*10     ,<aspect:praecantatio>*10); 
+<iceandfire:troll_weapon.column>                .setAspects(<aspect:mythus>*10    ,<aspect:aversio>*20        ,<aspect:tenebrae>*10     ,<aspect:praecantatio>*10); 
+
+#Swamp
+
+<minecraft:spawn_egg>.withTag({EntityTag: {id: "iceandfire:if_hydra"}})
+                                                .setAspects(<aspect:mythus>*100   ,<aspect:praecantatio>*100  ,<aspect:alkimia>*100    ,<aspect:victus>*200); 
+<entity:iceandfire:if_hydra>                    .setAspects(<aspect:mythus>*100   ,<aspect:praecantatio>*100  ,<aspect:alkimia>*100    ,<aspect:victus>*200); 
+<iceandfire:hydra_skull>                        .setAspects(<aspect:mythus>*50    ,<aspect:spiritus>*20       ,<aspect:alkimia>*50     ,<aspect:victus>*50);  #hydra
+<iceandfire:hydra_fang>                         .setAspects(<aspect:mythus>*10    ,<aspect:aversio>*10        ,<aspect:alkimia>*10);                          
+<iceandfire:hydra_heart>                        .setAspects(<aspect:mythus>*50    ,<aspect:praecantatio>*30   ,<aspect:alkimia>*50     ,<aspect:victus>*200); 
+
+<minecraft:spawn_egg>.withTag({EntityTag: {id: "iceandfire:stymphalianbird"}})
+                                                .setAspects(<aspect:mythus>*20    ,<aspect:aer>*10            ,<aspect:volatus>*20     ,<aspect:ventus>*20); 
+<entity:iceandfire:stymphalianbird>             .setAspects(<aspect:mythus>*20    ,<aspect:aer>*10            ,<aspect:volatus>*20     ,<aspect:ventus>*20); 
+<iceandfire:stymphalian_skull>                  .setAspects(<aspect:mythus>*15    ,<aspect:spiritus>*20       ,<aspect:volatus>*40     ,<aspect:ventus>*40);  #ironbird
+<iceandfire:stymphalian_bird_feather>           .setAspects(<aspect:mythus>*5     ,<aspect:aer>*5             ,<aspect:volatus>*5      ,<aspect:ventus>*5); 
+
+#Jungle
+
+<minecraft:spawn_egg>.withTag({EntityTag: {id: "iceandfire:amphithere"}})
+                                                .setAspects(<aspect:mythus>*25    ,<aspect:aer>*15            ,<aspect:volatus>*15     ,<aspect:desiderium>*20); 
+<entity:iceandfire:amphithere>                  .setAspects(<aspect:mythus>*25    ,<aspect:aer>*15            ,<aspect:volatus>*15     ,<aspect:desiderium>*20); 
+<iceandfire:amphithere_feather>                 .setAspects(<aspect:mythus>*5     ,<aspect:aer>*5             ,<aspect:volatus>*5      ,<aspect:desiderium>*20);  #amphithere
+<iceandfire:amphithere_skull>                   .setAspects(<aspect:mythus>*30    ,<aspect:spiritus>*20       ,<aspect:aer>*20         ,<aspect:volatus>*20);  
+
+<iceandfire:myrmex_jungle_chitin>               .setAspects(<aspect:mythus>*5     ,<aspect:praemunio>*5       ,<aspect:herba>*5); #jungle myrmex
+<iceandfire:myrmex_jungle_resin>                .setAspects(<aspect:mythus>*5     ,<aspect:permutatio>*5      ,<aspect:herba>*5); 
+<iceandfire:myrmex_jungle_egg:*>                .setAspects(<aspect:mythus>*20    ,<aspect:victus>*10         ,<aspect:herba>*5); 
+
+#Desert
+<minecraft:spawn_egg>.withTag({EntityTag: {id: "iceandfire:deathworm"}})
+                                                .setAspects(<aspect:mythus>*30    ,<aspect:vinculum>*20       ,<aspect:bestia>*50);
+<entity:iceandfire:deathworm>                   .setAspects(<aspect:mythus>*30    ,<aspect:vinculum>*20       ,<aspect:bestia>*50);
+<iceandfire:deathworm_chitin:*>                 .setAspects(<aspect:mythus>*5     ,<aspect:praemunio>*5       ,<aspect:bestia>*5); #deathworm
+<iceandfire:iceandfire.deathworm_egg:*>         .setAspects(<aspect:mythus>*10    ,<aspect:victus>*20         ,<aspect:bestia>*20); 
+<iceandfire:deathworm_tounge>                   .setAspects(<aspect:mythus>*20    ,<aspect:vinculum>*50       ,<aspect:bestia>*50);
+
+<iceandfire:myrmex_desert_chitin>               .setAspects(<aspect:mythus>*5     ,<aspect:praemunio>*5       ,<aspect:ignis>*5); #desert myrmex
+<iceandfire:myrmex_desert_resin>                .setAspects(<aspect:mythus>*5     ,<aspect:permutatio>*5      ,<aspect:ignis>*5); 
+<iceandfire:myrmex_desert_egg:*>                .setAspects(<aspect:mythus>*20    ,<aspect:victus>*10         ,<aspect:ignis>*5); 
+
+<minecraft:spawn_egg>.withTag({EntityTag: {id: "iceandfire:if_cockatrice"}})
+                                                .setAspects(<aspect:mythus>*10    ,<aspect:mortuus>*20        ,<aspect:motus>*20        ,<aspect:perditio>*30); 
+<entity:iceandfire:if_cockatrice>               .setAspects(<aspect:mythus>*10    ,<aspect:mortuus>*20        ,<aspect:motus>*20        ,<aspect:perditio>*30); 
+<iceandfire:cockatrice_skull>                   .setAspects(<aspect:mythus>*10    ,<aspect:spiritus>*20       ,<aspect:motus>*10        ,<aspect:perditio>*20);  #cockatrice
+<iceandfire:cockatrice_eye>                     .setAspects(<aspect:mythus>*20    ,<aspect:mortuus>*20        ,<aspect:motus>*10        ,<aspect:perditio>*50); 
+
+#Forest/plains
+
+<minecraft:spawn_egg>.withTag({EntityTag: {id: "iceandfire:hippogryph"}}) #hippogryph
+                                                .setAspects(<aspect:mythus>*50    ,<aspect:ventus>*50         ,<aspect:victus>*50);
+<entity:iceandfire:hippogryph>                  .setAspects(<aspect:mythus>*50    ,<aspect:ventus>*50         ,<aspect:victus>*50);
+<iceandfire:hippogryph_skull>                   .setAspects(<aspect:mythus>*20    ,<aspect:spiritus>*20       ,<aspect:ventus>*20       ,<aspect:victus>*40);  
+<iceandfire:hippogryph_egg:*>                   .setAspects(<aspect:mythus>*20    ,<aspect:victus>*40         ,<aspect:ventus>*40); 
+
+<minecraft:spawn_egg>.withTag({EntityTag: {id: "iceandfire:if_pixie"}}) #pixie
+                                                .setAspects(<aspect:mythus>*20    ,<aspect:praecantatio>*50   ,<aspect:humanus>*20      ,<aspect:desiderium>*50); 
+<entity:iceandfire:if_pixie>                    .setAspects(<aspect:mythus>*20    ,<aspect:praecantatio>*50   ,<aspect:humanus>*20      ,<aspect:desiderium>*50); 
+<iceandfire:pixie_dust>                         .setAspects(<aspect:mythus>*2     ,<aspect:praecantatio>*30   ,<aspect:humanus>*20      ,<aspect:desiderium>*5); 
+<iceandfire:ambrosia>                           .setAspects(<aspect:mythus>*2     ,<aspect:praecantatio>*40   ,<aspect:victus>*20       ,<aspect:desiderium>*20); 
+<iceandfire:jar_pixie:*>                        .setAspects(<aspect:mythus>*20    ,<aspect:praecantatio>*50   ,<aspect:humanus>*20      ,<aspect:desiderium>*50); 
+<iceandfire:pixie_wings>                        .setAspects(<aspect:mythus>*20    ,<aspect:praecantatio>*50   ,<aspect:imperium>*20     ,<aspect:desiderium>*50); 
+<iceandfire:pixie_house:*>                      .setAspects(<aspect:herba>*20     ,<aspect:auram>*5); 
+
+<minecraft:spawn_egg>.withTag({EntityTag: {id: "iceandfire:snowvillager"}})
+                                                .setAspects(<aspect:humanus>*20   ,<aspect:permutatio>*20     ,<aspect:desiderium>*20); 
+<entity:iceandfire:snowvillager>                .setAspects(<aspect:humanus>*20   ,<aspect:permutatio>*20     ,<aspect:desiderium>*20); 
+
+#Ice
+
+<iceandfire:dread_shard>                        .setAspects(<aspect:exanimis>*10  ,<aspect:perditio>*10       ,<aspect:spiritus>*20); 
+
+<minecraft:spawn_egg>.withTag({EntityTag: {id: "iceandfire:dread_thrall"}})
+                                                .setAspects(<aspect:exanimis>*20  ,<aspect:perditio>*20       ,<aspect:spiritus>*20); 
+<entity:iceandfire:dread_thrall>                .setAspects(<aspect:exanimis>*20  ,<aspect:perditio>*20       ,<aspect:spiritus>*20); 
+<minecraft:spawn_egg>.withTag({EntityTag: {id: "iceandfire:dread_beast"}})
+                                                .setAspects(<aspect:exanimis>*20  ,<aspect:bestia>*20         ,<aspect:spiritus>*20); 
+<entity:iceandfire:dread_beast>                 .setAspects(<aspect:exanimis>*20  ,<aspect:bestia>*20         ,<aspect:spiritus>*20); 
+<minecraft:spawn_egg>.withTag({EntityTag: {id: "iceandfire:dread_scuttler"}})
+                                                .setAspects(<aspect:exanimis>*20  ,<aspect:alkimia>*20        ,<aspect:spiritus>*20); 
+<entity:iceandfire:dread_scuttler>              .setAspects(<aspect:exanimis>*20  ,<aspect:alkimia>*20        ,<aspect:spiritus>*20); 
+<minecraft:spawn_egg>.withTag({EntityTag: {id: "iceandfire:dread_ghoul"}})
+                                                .setAspects(<aspect:exanimis>*20  ,<aspect:perditio>*20       ,<aspect:spiritus>*20); 
+<entity:iceandfire:dread_ghoul>                 .setAspects(<aspect:exanimis>*20  ,<aspect:perditio>*20       ,<aspect:spiritus>*20); 
+<minecraft:spawn_egg>.withTag({EntityTag: {id: "iceandfire:dread_knight"}})
+                                                .setAspects(<aspect:exanimis>*20  ,<aspect:metallum>*20       ,<aspect:spiritus>*20); 
+<entity:iceandfire:dread_knight>                .setAspects(<aspect:exanimis>*20  ,<aspect:metallum>*20       ,<aspect:spiritus>*20); 
+<minecraft:spawn_egg>.withTag({EntityTag: {id: "iceandfire:dread_horse"}})
+                                                .setAspects(<aspect:exanimis>*20  ,<aspect:motus>*20          ,<aspect:spiritus>*20); 
+<entity:iceandfire:dread_horse>                 .setAspects(<aspect:exanimis>*20  ,<aspect:motus>*20          ,<aspect:spiritus>*20); 
+<minecraft:spawn_egg>.withTag({EntityTag: {id: "iceandfire:dread_lich"}})
+                                                .setAspects(<aspect:exanimis>*20  ,<aspect:praecantatio>*20   ,<aspect:spiritus>*20); 
+<entity:iceandfire:dread_lich>                  .setAspects(<aspect:exanimis>*20  ,<aspect:praecantatio>*20   ,<aspect:spiritus>*20); 
+
+/*
+#######################################################
+
+Tinker's construct
+
+#######################################################
+*/
+
+<tconstruct:materials:17>                       .setAspects(<aspect:mortuus>*10      ,<aspect:infernum>*10    ,<aspect:tenebrae>*5       ,<aspect:perditio>*5); #wither bone
+
+/*
+#######################################################
+
+Vanilla
+
+#######################################################
+*/
+
+<minecraft:stone:3>                             .setAspects(<aspect:terra>*5      ,<aspect:ordo>); #diorite
+<minecraft:stone:5>                             .setAspects(<aspect:terra>*5      ,<aspect:perditio>); #andesite
+<minecraft:stone:1>                             .setAspects(<aspect:terra>*5      ,<aspect:ignis>); #granite
+
+<minecraft:skull:1>                             .setAspects(<aspect:spiritus>*10      ,<aspect:infernum>*10    ,<aspect:tenebrae>*5       ,<aspect:perditio>*5); #wither skull
+
 # Removing wrong aspects from stuff
 <conarm:armor_trim:*>.setAspects(<aspect:terra>);
 <harvestcraft:freshwateritem>.removeAspects(<aspect:metallum>);


### PR DESCRIPTION
Added aspect support for following mods:
-'Astral sorcery'
-'Blood magic'
-'Botania'
-'Ice and fire' (also gets support for entities for [Entity summoner])

New recipes:
-[Tattered scrolls] recipe for peaceful skyblock
-[Sigil of the whirlwind]

Fixes:
-[Native clusters] and [Energetic nitor] in [Thaumatorium]
-Removed duplicated recipe for [Weak blood shard]