### PR TITLE
fix Player Simulator item dupe

### DIFF
--- a/scripts/do/hand_over_your_items.zs
+++ b/scripts/do/hand_over_your_items.zs
@@ -34,10 +34,9 @@ events.onPlayerInteractEntity(function(e as crafttweaker.event.PlayerInteractEnt
     # Player must be targeting another player
     || !e.target instanceof IPlayer
     # Fix https://github.com/Krutoy242/Enigmatica2Expert-Extended/issues/280
-    || e.player.uuid == "41C82C87-7AfB-4024-BB57-13D2C99CAE77" 
+    || e.player.name == "[IntegratedTunnels]"
     # See https://github.com/CyclopsMC/IntegratedTunnels/blob/800584c534a7c6a00cd3bc8bc3cf8cb33d7d529e/src/main/java/org/cyclops/integratedtunnels/core/ExtendedFakePlayer.java#L16C2-L16C2
-    # Also https://github.com/rwtema/Extra-Utilities-2-Source/blob/9e478a1f48b559c404747c663cbb29bd8acf93d9/1.10.2/src/main/java/com/rwtema/extrautils2/fakeplayer/XUFakePlayer.java#L22
-    # But I cannot find Cyclic's UUID for FakePlayer, maybe it uses different apporaches. 
+    # Cyclic and ExtraUtilities2 does not support sneaking, so no need to handle that
   ) return;
 
   val item = e.player.getItemInSlot(mainHand);

--- a/scripts/do/hand_over_your_items.zs
+++ b/scripts/do/hand_over_your_items.zs
@@ -34,9 +34,7 @@ events.onPlayerInteractEntity(function(e as crafttweaker.event.PlayerInteractEnt
     # Player must be targeting another player
     || !e.target instanceof IPlayer
     # Fix https://github.com/Krutoy242/Enigmatica2Expert-Extended/issues/280
-    || e.player.name == "[IntegratedTunnels]"
-    # See https://github.com/CyclopsMC/IntegratedTunnels/blob/800584c534a7c6a00cd3bc8bc3cf8cb33d7d529e/src/main/java/org/cyclops/integratedtunnels/core/ExtendedFakePlayer.java#L16C2-L16C2
-    # Cyclic and ExtraUtilities2 does not support sneaking, so no need to handle that
+    || e.player.fake`e.player.fake`
   ) return;
 
   val item = e.player.getItemInSlot(mainHand);

--- a/scripts/do/hand_over_your_items.zs
+++ b/scripts/do/hand_over_your_items.zs
@@ -34,7 +34,7 @@ events.onPlayerInteractEntity(function(e as crafttweaker.event.PlayerInteractEnt
     # Player must be targeting another player
     || !e.target instanceof IPlayer
     # Fix https://github.com/Krutoy242/Enigmatica2Expert-Extended/issues/280
-    || e.player.fake`e.player.fake`
+    || e.player.fake
   ) return;
 
   val item = e.player.getItemInSlot(mainHand);

--- a/scripts/do/hand_over_your_items.zs
+++ b/scripts/do/hand_over_your_items.zs
@@ -29,8 +29,15 @@ val mainHand = crafttweaker.entity.IEntityEquipmentSlot.mainHand();
 
 events.onPlayerInteractEntity(function(e as crafttweaker.event.PlayerInteractEntityEvent){
   if(
+    # Player must be sneaking
     !e.player.isSneaking
+    # Player must be targeting another player
     || !e.target instanceof IPlayer
+    # Fix https://github.com/Krutoy242/Enigmatica2Expert-Extended/issues/280
+    || e.player.uuid == "41C82C87-7AfB-4024-BB57-13D2C99CAE77" 
+    # See https://github.com/CyclopsMC/IntegratedTunnels/blob/800584c534a7c6a00cd3bc8bc3cf8cb33d7d529e/src/main/java/org/cyclops/integratedtunnels/core/ExtendedFakePlayer.java#L16C2-L16C2
+    # Also https://github.com/rwtema/Extra-Utilities-2-Source/blob/9e478a1f48b559c404747c663cbb29bd8acf93d9/1.10.2/src/main/java/com/rwtema/extrautils2/fakeplayer/XUFakePlayer.java#L22
+    # But I cannot find Cyclic's UUID for FakePlayer, maybe it uses different apporaches. 
   ) return;
 
   val item = e.player.getItemInSlot(mainHand);


### PR DESCRIPTION
## Summary
see #280. This PR fixes that. 

## Technical details
I use `e.player.fake` to determine if a player is FakePlayer. If is, simply skip `hand over your items` processing. 

~~Thankfully, IntgDyn gives the name that its FakePlayer uses : `[IntegratedTunnels]` .~~
~~references: https://github.com/CyclopsMC/IntegratedTunnels/blob/800584c534a7c6a00cd3bc8bc3cf8cb33d7d529e/src/main/java/org/cyclops/integratedtunnels/core/ExtendedFakePlayer.java#L16C2-L16C2~~

As for Cyclic and ExtraUtilities2, their Player Simulator does not support sneaking, so no need to handle that. 

## Deprecated Alternative Methods
-  use `isFake()` function

`IPlayer` in 1.12 does not actually provides this method(getter) . While it's true that there is a global function call `isFake()` that accepts `crafttweaker.player.IPlayer` as arg , it does not work well with `IntegratedTunnels` , outputing errors like this: 
```
[SERVER_STARTED][SERVER][ERROR] Truncated class file
java.lang.ClassFormatError: Truncated class file
   ...
```

- use UUID comparision 

not usable for unknown reason

- use name comparision 

use `e.player.fake` instead, for better mod compability