### PR TITLE
Rebuild hand_over feature and tellrawItem() function

### DIFF
--- a/scripts/do/hand_over_your_items.zs
+++ b/scripts/do/hand_over_your_items.zs
@@ -10,61 +10,72 @@
 import crafttweaker.player.IPlayer;
 import crafttweaker.item.IItemStack;
 
-game.setLocalization('en_us', 'chat.handitem.you_have_given'     , 'You have given');
-game.setLocalization('en_us', 'chat.handitem.to'                 , 'to');
-game.setLocalization('en_us', 'chat.handitem.you_have_been_given', 'You have been given');
-game.setLocalization('en_us', 'chat.handitem.by'                 , 'by');
+for lang, entries in {
+  en_us: {
+    send   : 'You have given %s to %s',
+    receive: 'You have been given %s by %s'
+  },
+  ru_ru: {
+    send   : 'Вы передали %s игроку %s',
+    receive: 'Вам передали %s от игрока %s'
+  }
+  zh_cn: {
+    send   : '你已经将 %s 交给 %s',
+    receive: '你获得了 %s ，来自 %s'
+  },
+} as string[string][string] {
+  for key, value in entries {
+    game.setLocalization(lang, 'chat.hand_over_your_items.'~k, value);
+  }
+}
 
-game.setLocalization('ru_ru', 'chat.handitem.you_have_given'     , 'Вы передали');
-game.setLocalization('ru_ru', 'chat.handitem.to'                 , 'игроку');
-game.setLocalization('ru_ru', 'chat.handitem.you_have_been_given', 'Вам передали');
-game.setLocalization('ru_ru', 'chat.handitem.by'                 , 'от игрока');
+val MAIN_HAND = crafttweaker.entity.IEntityEquipmentSlot.mainHand();
 
-game.setLocalization('zh_cn', 'chat.handitem.you_have_given'     , '你已经将');
-game.setLocalization('zh_cn', 'chat.handitem.to'                 , '交给');
-game.setLocalization('zh_cn', 'chat.handitem.you_have_been_given', '你获得了');
-game.setLocalization('zh_cn', 'chat.handitem.by'                 , '，来自');
-
-val mainHand = crafttweaker.entity.IEntityEquipmentSlot.mainHand();
-
-events.onPlayerInteractEntity(function(e as crafttweaker.event.PlayerInteractEntityEvent){
-  if(
+events.onPlayerInteractEntity(function(event as crafttweaker.event.PlayerInteractEntityEvent){
+  var player = event.player;
+  if (
+    // Fake player not allowed
+    player.fake
     // Player must be sneaking
-    !e.player.isSneaking
+    || !player.isSneaking
+    // Player must be holding something
+    || !player.hasItemInSlot(MAIN_HAND)
+  ) {
+    return;
+  }
+  var target as IPlayer = event.target;
+  if (
     // Player must be targeting another player
-    || !e.target instanceof IPlayer
-    // Forbid fake players
-    || e.player.fake
-  ) return;
+    !(target instanceof IPlayer)
+  ) {
+    return;
+  }
 
-  val item = e.player.getItemInSlot(mainHand);
-  if(isNull(item)) return;
-
-  // Cancel event on both sides
-  e.cancel();
+  // Cancel original interact event on both sides
+  event.cancel();
 
   // Next only server-side actions
-  if(e.world.remote) return;
+  if(event.world.remote) {
+    return;
+  }
 
-  e.player.setItemToSlot(mainHand, null);
-
-  val targetPlayer as IPlayer = e.target;
-  targetPlayer.give(item);
-  // val targetPlayer = e.player;
+  var item = player.mainHandHeldItem;
+  target.give(item);
+  player.setItemToSlot(MAIN_HAND, null);
 
   // Sender message
-  utils.tellrawSend(e.player,
-     '{"translate":"chat.handitem.you_have_given","color":"blue"},{"text":" "}'
-    ~','~utils.tellrawItem(item, 'white')
-    ~',{"text":" "},{"translate":"chat.handitem.to","color":"blue"},{"text":" "}'
-    ~',{"text":"'~targetPlayer.name~'","color":"dark_blue"}'
+  utils.tellrawSend(player,
+    '{"translate":"chat.hand_over_your_items.send","color":"blue","with":['
+      ~utils.tellrawItem(item, 'white')
+      ~',{"text":"'~target.name~'","color":"dark_blue"}'
+    ~']}'
   );
 
   // Receiver message
-  utils.tellrawSend(targetPlayer,
-     '{"translate":"chat.handitem.you_have_been_given","color":"dark_green"},{"text":" "}'
-    ~','~utils.tellrawItem(item, 'white')
-    ~',{"text":" "},{"translate":"chat.handitem.by","color":"dark_green"},{"text":" "}'
-    ~',{"text":"'~e.player.name~'","color":"green"}'
+  utils.tellrawSend(target,
+    '{"translate":"chat.hand_over_your_items.receive","color":"dark_green","with":['
+      ~utils.tellrawItem(item, 'white')
+      ~',{"text":"'~player.name~'","color":"green"}'
+    ~']}'
   );
 });

--- a/scripts/do/hand_over_your_items.zs
+++ b/scripts/do/hand_over_your_items.zs
@@ -31,8 +31,8 @@ for lang, entries in {
 
 val MAIN_HAND = crafttweaker.entity.IEntityEquipmentSlot.mainHand();
 
-events.onPlayerInteractEntity(function(event as crafttweaker.event.PlayerInteractEntityEvent){
-  var player = event.player;
+events.onPlayerInteractEntity(function(e as crafttweaker.event.PlayerInteractEntityEvent){
+  var player = e.player;
   if (
     // Fake player not allowed
     player.fake
@@ -41,20 +41,19 @@ events.onPlayerInteractEntity(function(event as crafttweaker.event.PlayerInterac
     // Player must be holding something
     || !player.hasItemInSlot(MAIN_HAND)
     // Player must be targeting another player
-    || !(event.target instanceof IPlayer)
+    || !(e.target instanceof IPlayer)
   ) {
     return;
   }
 
   // Cancel original interact event on both sides
-  event.cancel();
-
+  e.cancel();
   // Next only server-side actions
-  if(event.world.remote) {
+  if(e.world.remote) {
     return;
   }
 
-  var target as IPlayer = event.target;
+  var target as IPlayer = e.target;
   var item = player.mainHandHeldItem;
   target.give(item);
   player.setItemToSlot(MAIN_HAND, null);

--- a/scripts/do/hand_over_your_items.zs
+++ b/scripts/do/hand_over_your_items.zs
@@ -18,14 +18,14 @@ for lang, entries in {
   ru_ru: {
     send   : 'Вы передали %s игроку %s',
     receive: 'Вам передали %s от игрока %s'
-  }
+  },
   zh_cn: {
     send   : '你已经将 %s 交给 %s',
     receive: '你获得了 %s ，来自 %s'
   },
 } as string[string][string] {
   for key, value in entries {
-    game.setLocalization(lang, 'chat.hand_over_your_items.'~k, value);
+    game.setLocalization(lang, 'chat.hand_over_your_items.'~key, value);
   }
 }
 

--- a/scripts/do/hand_over_your_items.zs
+++ b/scripts/do/hand_over_your_items.zs
@@ -40,13 +40,8 @@ events.onPlayerInteractEntity(function(event as crafttweaker.event.PlayerInterac
     || !player.isSneaking
     // Player must be holding something
     || !player.hasItemInSlot(MAIN_HAND)
-  ) {
-    return;
-  }
-  var target as IPlayer = event.target;
-  if (
     // Player must be targeting another player
-    !(target instanceof IPlayer)
+    || !(event.target instanceof IPlayer)
   ) {
     return;
   }
@@ -59,6 +54,7 @@ events.onPlayerInteractEntity(function(event as crafttweaker.event.PlayerInterac
     return;
   }
 
+  var target as IPlayer = event.target;
   var item = player.mainHandHeldItem;
   target.give(item);
   player.setItemToSlot(MAIN_HAND, null);

--- a/scripts/lib/utils.zs
+++ b/scripts/lib/utils.zs
@@ -451,6 +451,8 @@ zenClass Utils {
         ~amount
         ~name
         ~'{"text":""}'
+        // `{"text":""}` is used so that when `showName` is false, the text can still be displayed.
+        // This also allows for simpler comma handling
       ~']}';
   }
 

--- a/scripts/lib/utils.zs
+++ b/scripts/lib/utils.zs
@@ -439,7 +439,7 @@ zenClass Utils {
       : ',"color":"'~color~'"';
     val displayName = item.hasDisplayName
       ? '"'~item.tag.display.Name.asString()~'"'
-      : '{"translate":"'~item.definition.name~'.name"}';
+      : '{"translate":"'~item.name~'.name"}';
 
     val amount = item.amount > 1
       ? '{"translate":"%s ","with":["'~item.amount~'"]'~colorTag~'},'

--- a/scripts/lib/utils.zs
+++ b/scripts/lib/utils.zs
@@ -433,22 +433,25 @@ zenClass Utils {
      ██║   ███████╗███████╗███████╗██║  ██║██║  ██║╚███╔███╔╝
      ╚═╝   ╚══════╝╚══════╝╚══════╝╚═╝  ╚═╝╚═╝  ╚═╝ ╚══╝╚══╝ 
   */
-  function tellrawItem(item as IItemStack, color as string = null, addName as bool = true) as string {
-    val colorTag = isNull(color) ? '' : ',"color":"'~color~'"';
-    val amount = item.amount > 1 ? '{"text":"'~item.amount~'"'~colorTag~'},{"text":" "},' : '';
-    val itemName =
-    '{"text":"\u00A7f   ","hoverEvent":'
-        ~'{"action":"show_item","value":"'
-          ~item.asData().toNBTString().replaceAll('"', '\\\\"')
-        ~'"}'
-      ~(addName ? (',"extra":['
-        ~'{"text":"["'~colorTag~'}'
-        ~',{"translate":"'~item.name~'.name"'~colorTag~'}'
-        ~',{"text":"]"'~colorTag~'}'
-      ~']') : '')
-    ~'}';
+  function tellrawItem(item as IItemStack, color as string = null, showName as bool = true) as string {
+    val colorTag = isNull(color)
+      ? ''
+      : ',"color":"'~color~'"';
+    val amount = item.amount > 1
+      ? '{"translate":"%s ","with":["'~item.amount~'"]'~colorTag~'},'
+      : '';
+    val name = showName 
+      ? '{"translate":"[%s]","with":["'~item.displayName~'"]'~colorTag~'},'
+      : '';
 
-    return amount ~ itemName;
+    return 
+      '{"text":"\u00A7f   ","hoverEvent":{"action":"show_item","value":"'
+        ~item.asData().toNBTString().replaceAll('"', '\\\\"')
+      ~'"},"extra":['
+        ~amount
+        ~name
+        ~'{"text":""}'
+      ~']}';
   }
 
   function tellrawSend(player as IPlayer, message as string) as void {

--- a/scripts/lib/utils.zs
+++ b/scripts/lib/utils.zs
@@ -441,19 +441,13 @@ zenClass Utils {
       ? '{"translate":"%s ","with":["'~item.amount~'"]'~colorTag~'},'
       : '';
     val name = showName 
-      ? '{"translate":"[%s]","with":["'~item.displayName~'"]'~colorTag~'},'
+      ? ',{"translate":"[%s]","with":["'~item.displayName~'"]'~colorTag~'}'
       : '';
-
-    return 
+    val iconQuark = 
       '{"text":"\u00A7f   ","hoverEvent":{"action":"show_item","value":"'
         ~item.asData().toNBTString().replaceAll('"', '\\\\"')
-      ~'"},"extra":['
-        ~amount
-        ~name
-        ~'{"text":""}'
-        // `{"text":""}` is used so that when `showName` is false, the text can still be displayed.
-        // This also allows for simpler comma handling
-      ~']}';
+      ~'"}}';
+    return '{"text":"","extra":['~amount~iconQuark~name~']}';
   }
 
   function tellrawSend(player as IPlayer, message as string) as void {

--- a/scripts/lib/utils.zs
+++ b/scripts/lib/utils.zs
@@ -437,13 +437,15 @@ zenClass Utils {
     val colorTag = isNull(color)
       ? ''
       : ',"color":"'~color~'"';
+    val displayName = item.hasDisplayName
+      ? '"'~item.tag.display.Name.asString()~'"'
+      : '{"translate":"'~item.definition.name~'.name"}';
+
     val amount = item.amount > 1
       ? '{"translate":"%s ","with":["'~item.amount~'"]'~colorTag~'},'
       : '';
-    // NOTE: the name display is not perfect, due to its inability to show custom name
-    // say a Stone that's renamed to "Rock", it will only display "Stone"
     val name = showName 
-      ? ',{"translate":"[%s]","with":[{"translate":"'~item.definition.name~'.name"}]'~colorTag~'}'
+      ? ',{"translate":"[%s]","with":['~displayName~']'~colorTag~'}'
       : '';
     // The major part of `iconQuark` is actually 3 spaces, which are reserved for Quark item rendering
     // So you needs Quark to get the icon

--- a/scripts/lib/utils.zs
+++ b/scripts/lib/utils.zs
@@ -440,13 +440,18 @@ zenClass Utils {
     val amount = item.amount > 1
       ? '{"translate":"%s ","with":["'~item.amount~'"]'~colorTag~'},'
       : '';
+    // NOTE: the name display is not perfect, due to its inability to show custom name
+    // say a Stone that's renamed to "Rock", it will only display "Stone"
     val name = showName 
-      ? ',{"translate":"[%s]","with":["'~item.displayName~'"]'~colorTag~'}'
+      ? ',{"translate":"[%s]","with":[{"translate":"'~item.definition.name~'.name"}]'~colorTag~'}'
       : '';
+    // The major part of `iconQuark` is actually 3 spaces, which are reserved for Quark item rendering
+    // So you needs Quark to get the icon
     val iconQuark = 
       '{"text":"\u00A7f   ","hoverEvent":{"action":"show_item","value":"'
         ~item.asData().toNBTString().replaceAll('"', '\\\\"')
       ~'"}}';
+    // Combine these pieces together, and return it
     return '{"text":"","extra":['~amount~iconQuark~name~']}';
   }
 


### PR DESCRIPTION
This PR targets at modernize feature::hand_over_your_items and function::tellrawItem()
## Summary
### For users
- Items with custom name can get their name displayed properly. 
Let's take a stone that's renamed to `Rock` for example. It will now display `Rock` instead of `Stone` .

### For developers
In hand_over_your_items feature: 
- lang entries for localization are simplified into 2 entries(was 4) , and provides `%s` placeholders
- messages processing are reorganized to be clearer

In tellrawItem() function: 
- move from string concat to "translate":"xxx %s xxx". this makes the overall structure clearer
- auto detection for custom name
- variable re-naming and manual formatting
- important: returned entry parts are now bundled in a single structure. This avoids wrongly consuming `%s` or other placeholder

## Test
Sender Message && Receiver Message:
This image shows what will happen when handling sender/receiver, original/custom name, and different languages. 
<img width="450" alt="image" src="https://github.com/Krutoy242/Enigmatica2Expert-Extended/assets/47418975/a8aa1f52-ce8c-4054-b8bc-05eae9d8df0b">

Older image, not valid now:
This is done by manually disabling fakeplayer logic, which should not affect anything. Screenshots below.
![image](https://github.com/Krutoy242/Enigmatica2Expert-Extended/assets/47418975/db33c2b2-08e6-4ae6-b366-b9d53545e5f8)
