### PR TITLE
remove glass block from skyblock

### DIFF
--- a/config/justenoughdimensions/dimensions.json
+++ b/config/justenoughdimensions/dimensions.json
@@ -16,7 +16,7 @@
 				"SpawnY": 89
 			},
 			"jed": {
-				"GenerateFallbackSpawnBlock": true
+				"GenerateFallbackSpawnBlock": false
 			}
 		}
 	]


### PR DESCRIPTION
The fallback spawn block could be useful for a building dimension, but not for skyblock.