### PR TITLE
Fix /gamestage command typo

### DIFF
--- a/config/ftbquests/normal/chapters/4f65de69/b1868c44.snbt
+++ b/config/ftbquests/normal/chapters/4f65de69/b1868c44.snbt
@@ -47,7 +47,7 @@
 		title: "Grand access to the Nether",
 		team_reward: true,
 		auto: "no_toast",
-		command: "/gamestages add @p healthy"
+		command: "/gamestage add @p healthy"
 	},
 	{
 		uid: "cbe428c2",


### PR DESCRIPTION
checked with [crafttweaker 1.12 docs](https://docs.blamejared.com/1.12/en/Mods/GameStages/GameStages)