### PR TITLE
feat: add exhaust steam cooling to cooling tower recipe

### DIFF
--- a/scripts/mods/immersivetech.zs
+++ b/scripts/mods/immersivetech.zs
@@ -129,6 +129,7 @@ mods.immersivetechnology.CoolingTower.removeRecipe(<liquid:hot_spring_water>, <l
 
 // mods.immersivetechnology.CoolingTower.addRecipe(ILiquidStack outputFluid1, ILiquidStack outputFluid2, ILiquidStack outputFluid3, ILiquidStack inputFluid1, ILiquidStack inputFluid2, int time);
 mods.immersivetechnology.CoolingTower.addRecipe(<liquid:water> * 5850, <liquid:water> * 5850, <liquid:water> * 5850, <liquid:hot_spring_water> * 8100, <liquid:water> * 9900, 1);
+mods.immersivetechnology.CoolingTower.addRecipe(<liquid:water> * 600, <liquid:water> * 600, <liquid:water> * 600, <liquid:exhaust_steam> * 800, <liquid:water> * 1000, 1);
 
 // --------------
 // Radiator buff x6


### PR DESCRIPTION
In my opinion, there should have been a cooling tower recipe for exhaust steam, seeing as it's produced in a nuclear reactor. In real life, nukes have giant cooling towers nearby - Why not here? For me it looks better than the radiator. I've tried to mimic your approach to the ratios but feel free to do whatever you want with the balancing here.

Currently:

800 exhaust and 1000 water make 1800 water over 1 tick.