### PR TITLE
Fast mineral sampling

### DIFF
--- a/scripts/do/mineral_sampling.zs
+++ b/scripts/do/mineral_sampling.zs
@@ -3,87 +3,85 @@
 
 /**
  * Fast mineral sampling
- * 
- * usage: 
+ *
+ * usage:
  * -player must be sneaking
  * -player must be holding a hammer from TCon in it's main hand
  * -player must be targeting a Sample Drill
  * -The hammer must has an NBT element named "FluxedEnergy", in integar, as its energy value
  *     -This can be achieved by "Flux Infused" modifier from TCon Evo
  * -The energy of this hammer must be no less than `ENERGY_COST`
- * 
+ *
  * if all matches:
  * -the energy of this hammer will decrease by the value of `ENERGY_COST`
  * -a mineral sample will be generated
  *     -the position that the sample represents is the position of Sample Drill
  * -player will be given this sample
  * -the hammer will recive a cooldown of 20 ticks
- * 
+ *
  * @author ZZZank
- * 
+ *
  * @see blusunrize.immersiveengineering.common.blocks.metal.TileEntitySampleDrill
  * @see blusunrize.immersiveengineering.api.tool.ExcavatorHandler
  */
 
-import crafttweaker.event.PlayerInteractBlockEvent;
-import mods.contenttweaker.BlockState;
 import crafttweaker.data.IData;
 import crafttweaker.entity.IEntityEquipmentSlot;
-
+import crafttweaker.event.PlayerInteractBlockEvent;
 import native.blusunrize.immersiveengineering.api.tool.ExcavatorHandler;
 import native.blusunrize.immersiveengineering.common.blocks.metal.TileEntitySampleDrill;
 
-val ENERGY_COST = 8000 * 10; //base cost is 8000RF, we make it 10 times bigger as the cost of saving time
+val ENERGY_COST = 8000 * 10; // base cost is 8000RF, we make it 10 times bigger as the cost of saving time
 
-events.onPlayerInteractBlock(function(event as PlayerInteractBlockEvent) {
-    val player = event.player;
-    val item = event.item;
-    val block = event.block;
-    val world = event.world;
+events.onPlayerInteractBlock(function (event as PlayerInteractBlockEvent) {
+  val player = event.player;
+  val item = event.item;
+  val block = event.block;
+  val world = event.world;
 
-    //skip invalid interactions
-    if (
-        event.canceled
-        || player.fake
-        || !player.isSneaking
-        || event.hand != "MAIN_HAND"
-        || !(<item:tconstruct:hammer>.matches(item))
-        || block.definition.id != "immersiveengineering:metal_device1"
-    ) {
-        return;
-    }
+  // skip invalid interactions
+  if (
+    event.canceled
+    || player.fake
+    || !player.isSneaking
+    || event.hand != 'MAIN_HAND'
+    || !(<item:tconstruct:hammer>.matches(item))
+    || block.definition.id != 'immersiveengineering:metal_device1'
+  ) {
+    return;
+  }
 
-    //energy-based interaction filtering, consume energy
-    val energy = item.tag.memberGet("FluxedEnergy") as int;
-    if (energy < ENERGY_COST) {
-        return;
-    }
-    player.setItemToSlot(
-        IEntityEquipmentSlot.mainHand(),
-        item.updateTag({"FluxedEnergy": (energy - ENERGY_COST)} as IData)
-    );
-    
-    //get mineral sample
-    val nativeWorld = world.native;
-    val nativePlayer = player.native;
-    val drill = nativeWorld.getTileEntity(event.position.native) as TileEntitySampleDrill;
-    /**
+  // energy-based interaction filtering, consume energy
+  val energy = item.tag.memberGet('FluxedEnergy') as int;
+  if (energy < ENERGY_COST) {
+    return;
+  }
+  player.setItemToSlot(
+    IEntityEquipmentSlot.mainHand(),
+    item.updateTag({ 'FluxedEnergy': (energy - ENERGY_COST) } as IData)
+  );
+
+  // get mineral sample
+  val nativeWorld = world.native;
+  val nativePlayer = player.native;
+  val drill = nativeWorld.getTileEntity(event.position.native) as TileEntitySampleDrill;
+  /**
     @see blusunrize.immersiveengineering.common.blocks.metal.TileEntitySampleDrill
     @see blusunrize.immersiveengineering.api.tool.ExcavatorHandler
      */
-    val worldInfo = ExcavatorHandler.getMineralWorldInfo(
-        nativeWorld,
-        nativePlayer.chunkCoordX,
-        nativePlayer.chunkCoordZ
-    );
+  val worldInfo = ExcavatorHandler.getMineralWorldInfo(
+    nativeWorld,
+    nativePlayer.chunkCoordX,
+    nativePlayer.chunkCoordZ
+  );
     val sample = drill.createCoreSample(
-        nativeWorld,
-        nativePlayer.chunkCoordX,
-        nativePlayer.chunkCoordZ,
-        worldInfo
-    );
+    nativeWorld,
+    nativePlayer.chunkCoordX,
+    nativePlayer.chunkCoordZ,
+    worldInfo
+  );
 
-    //give item, and prevent players from clicking multiple times, because one sample is enough for one chunk
-    player.give(sample.wrapper);
-    player.setCooldown(item, 20);
+  // give item, and prevent players from clicking multiple times, because one sample is enough for one chunk
+  player.give(sample.wrapper);
+  player.setCooldown(item, 20);
 });

--- a/scripts/do/mineral_sampling.zs
+++ b/scripts/do/mineral_sampling.zs
@@ -1,0 +1,89 @@
+#modloaded zenutils immersiveengineering
+#reloadable
+
+/**
+ * Fast mineral sampling
+ * 
+ * usage: 
+ * -player must be sneaking
+ * -player must be holding a hammer from TCon in it's main hand
+ * -player must be targeting a Sample Drill
+ * -The hammer must has an NBT element named "FluxedEnergy", in integar, as its energy value
+ *     -This can be achieved by "Flux Infused" modifier from TCon Evo
+ * -The energy of this hammer must be no less than `ENERGY_COST`
+ * 
+ * if all matches:
+ * -the energy of this hammer will decrease by the value of `ENERGY_COST`
+ * -a mineral sample will be generated
+ *     -the position that the sample represents is the position of Sample Drill
+ * -player will be given this sample
+ * -the hammer will recive a cooldown of 20 ticks
+ * 
+ * @author ZZZank
+ * 
+ * @see blusunrize.immersiveengineering.common.blocks.metal.TileEntitySampleDrill
+ * @see blusunrize.immersiveengineering.api.tool.ExcavatorHandler
+ */
+
+import crafttweaker.event.PlayerInteractBlockEvent;
+import mods.contenttweaker.BlockState;
+import crafttweaker.data.IData;
+import crafttweaker.entity.IEntityEquipmentSlot;
+
+import native.blusunrize.immersiveengineering.api.tool.ExcavatorHandler;
+import native.blusunrize.immersiveengineering.common.blocks.metal.TileEntitySampleDrill;
+
+val ENERGY_COST = 8000 * 10; //base cost is 8000RF, we make it 10 times bigger as the cost of saving time
+
+events.onPlayerInteractBlock(function(event as PlayerInteractBlockEvent) {
+    val player = event.player;
+    val item = event.item;
+    val block = event.block;
+    val world = event.world;
+
+    //skip invalid interactions
+    if (
+        event.canceled
+        || player.fake
+        || !player.isSneaking
+        || event.hand != "MAIN_HAND"
+        || !(<item:tconstruct:hammer>.matches(item))
+        || block.definition.id != "immersiveengineering:metal_device1"
+    ) {
+        return;
+    }
+
+    //energy-based interaction filtering, consume energy
+    val energy = item.tag.memberGet("FluxedEnergy") as int;
+    if (energy < ENERGY_COST) {
+        return;
+    }
+    player.setItemToSlot(
+        IEntityEquipmentSlot.mainHand(),
+        item.updateTag({"FluxedEnergy": (energy - ENERGY_COST)} as IData)
+    );
+    
+    //get mineral sample
+    val nativeWorld = world.native;
+    val nativePlayer = player.native;
+    val drill = nativeWorld.getTileEntity(event.position.native) as TileEntitySampleDrill;
+    /**
+    @see blusunrize.immersiveengineering.common.blocks.metal.TileEntitySampleDrill
+    @see blusunrize.immersiveengineering.api.tool.ExcavatorHandler
+     */
+    val worldInfo = ExcavatorHandler.getMineralWorldInfo(
+        nativeWorld,
+        nativePlayer.chunkCoordX,
+        nativePlayer.chunkCoordZ
+    );
+    val sample = drill.createCoreSample(
+        nativeWorld,
+        nativePlayer.chunkCoordX,
+        nativePlayer.chunkCoordZ,
+        worldInfo
+    );
+
+    //give item, and prevent players from clicking multiple times, because one sample is enough for one chunk
+    player.give(sample.wrapper);
+    player.setCooldown(item, 20);
+});


### PR DESCRIPTION
This is sort of a proof-of-concept PR, so feel free close this PR if you think it's too rough / not matching progression.

The main goal of this PR is to replace PortableDrill, because obtaining a mineral sample only by clicking once looks too simple for me, so simple to a point that it seems dull. And, players might use the portabl drill multiple times in a short time(possiblly by accident, or a broken mouse), causing them to get multiple identical samples, which will be annoying. 

This PR adds a new mechanism, where players should be holding a TCon Hammer with energy in it, and right-click SampleDrill block to obtain a sample without having to wait.

A more detailed explaination is avaliable in the script source code.

Example:

https://github.com/Krutoy242/Enigmatica2Expert-Extended/assets/47418975/e4b06d76-16e8-4158-a420-9235e94ff74a

