### PR TITLE
Buffs to EnderIO Grinding Balls' durability

### DIFF
--- a/config/enderio/recipes/user/user_recipes.xml
+++ b/config/enderio/recipes/user/user_recipes.xml
@@ -622,7 +622,7 @@
   <recipe name="Alloy: Black Dye, Variant">
     <disabled/>
   </recipe>
-  <grindingball name="Fur Ball" grinding="1.0" chance="1.0" power="0.25" durability="8000">
+  <grindingball name="Fur Ball" grinding="1.0" chance="1.0" power="0.25" durability="64000">
     <item name="actuallyadditions:item_hairy_ball"/>
   </grindingball>
   <!-- Endergy Grinding Balls -->

--- a/config/enderio/recipes/user/user_recipes.xml
+++ b/config/enderio/recipes/user/user_recipes.xml
@@ -694,7 +694,7 @@
   <grindingball name="Stellar Alloy Ball" grinding="2.3" chance="2.25" power="2.2" durability="1088000" >
     <item name="ballStellarAlloy"/>
   </grindingball>
-  <grindingball name="Crystalline Pink Slime Ball" grinding="1.75" chance="1.55" power="1.55" durability="496000" >
+  <grindingball name="Crystalline Pink Slime Ball" grinding="1.75" chance="1.55" power="1.55" durability="620000" >
     <item name="ballCrystallinePinkSlime"/>
   </grindingball>
   <grindingball name="Vivid Alloy Ball" grinding="1.75" chance="1.35" power="1.35" durability="544000" >

--- a/config/enderio/recipes/user/user_recipes.xml
+++ b/config/enderio/recipes/user/user_recipes.xml
@@ -688,7 +688,7 @@
   <grindingball name="Crystalline Alloy Ball" grinding="1.8" chance="1.4" power="1.45" durability="304000" >
     <item name="ballCrystallineAlloy"/>
   </grindingball>
-  <grindingball name="Melodic Alloy Ball" grinding="2.0" chance="1.45" power="1.55" durability="336000" >
+  <grindingball name="Melodic Alloy Ball" grinding="2.0" chance="1.45" power="1.55" durability="840000" >
     <item name="ballMelodicAlloy"/>
   </grindingball>
   <grindingball name="Stellar Alloy Ball" grinding="2.3" chance="2.25" power="2.2" durability="1088000" >

--- a/config/enderio/recipes/user/user_recipes.xml
+++ b/config/enderio/recipes/user/user_recipes.xml
@@ -691,7 +691,7 @@
   <grindingball name="Melodic Alloy Ball" grinding="2.0" chance="1.45" power="1.55" durability="840000" >
     <item name="ballMelodicAlloy"/>
   </grindingball>
-  <grindingball name="Stellar Alloy Ball" grinding="2.3" chance="2.25" power="2.2" durability="1088000" >
+  <grindingball name="Stellar Alloy Ball" grinding="2.3" chance="2.25" power="2.2" durability="1632000" >
     <item name="ballStellarAlloy"/>
   </grindingball>
   <grindingball name="Crystalline Pink Slime Ball" grinding="1.75" chance="1.55" power="1.55" durability="620000" >

--- a/config/enderio/recipes/user/user_recipes.xml
+++ b/config/enderio/recipes/user/user_recipes.xml
@@ -697,7 +697,7 @@
   <grindingball name="Crystalline Pink Slime Ball" grinding="1.75" chance="1.55" power="1.55" durability="496000" >
     <item name="ballCrystallinePinkSlime"/>
   </grindingball>
-  <grindingball name="Vivid Alloy Ball" grinding="1.75" chance="1.35" power="1.35" durability="272000" >
+  <grindingball name="Vivid Alloy Ball" grinding="1.75" chance="1.35" power="1.35" durability="544000" >
     <item name="ballVividAlloy"/>
   </grindingball>
   <!-- Dyes remake -->

--- a/config/enderio/recipes/user/user_recipes.xml
+++ b/config/enderio/recipes/user/user_recipes.xml
@@ -670,7 +670,7 @@
   <grindingball name="Soularium Ball" grinding="1.2" chance="2.15" power="0.9" durability="177000" >
     <item name="ballSoularium"/>
   </grindingball>
-  <grindingball name="End Steel Ball" grinding="1.4" chance="2.4" power="0.7" durability="214000" >
+  <grindingball name="End Steel Ball" grinding="1.4" chance="2.4" power="0.7" durability="375000" >
     <item name="ballEndSteel"/>
   </grindingball>
   <grindingball name="Construction Alloy Ball" grinding="1.0" chance="0.33" power="0.25" durability="96000" >

--- a/config/enderio/recipes/user/user_recipes.xml
+++ b/config/enderio/recipes/user/user_recipes.xml
@@ -679,7 +679,7 @@
   <grindingball name="Signalum Ball" grinding="1.2" chance="1.65" power="0.35" durability="571000" >
     <item name="SIGNALUM_BALL"/>
   </grindingball>
-  <grindingball name="Enderium Ball" grinding="1.65" chance="1.45" power="1.25" durability="360000" >
+  <grindingball name="Enderium Ball" grinding="1.65" chance="1.45" power="1.25" durability="400000" >
     <item name="ENDERIUM_BALL"/>
   </grindingball>
   <grindingball name="Lumium Ball" grinding="1.1" chance="2.15" power="0.9" durability="222000" >
@@ -697,7 +697,7 @@
   <grindingball name="Crystalline Pink Slime Ball" grinding="1.75" chance="1.55" power="1.55" durability="620000" >
     <item name="ballCrystallinePinkSlime"/>
   </grindingball>
-  <grindingball name="Vivid Alloy Ball" grinding="1.75" chance="1.35" power="1.35" durability="544000" >
+  <grindingball name="Vivid Alloy Ball" grinding="1.75" chance="1.35" power="1.35" durability="598000" >
     <item name="ballVividAlloy"/>
   </grindingball>
   <!-- Dyes remake -->

--- a/config/enderio/recipes/user/user_recipes.xml
+++ b/config/enderio/recipes/user/user_recipes.xml
@@ -638,6 +638,68 @@
   <recipe name="Alloy: Vivid Alloy">
     <disabled/>
   </recipe>
+  <!-- Grinding Ball buffs
+  - Increased durability of all balls by 2x to account for required power for most of grinding recipes being lower, than SAG Mill's actual consumption (3200 RF < 5000 RF/t)
+  - For balls with Power Use less than 1x, additionally increased durability by (1 / Power Use)x to make them last as long as in vanilla EnderIO
+  - For balls with Power Use more than 1x, additionally increased durability by ((Power Use - 1) * 2)x to allow them to be still viable alongside with (Power Use < 1) balls and still have "more expensive -> more durable" progression
+  -->
+  <grindingball name="Flint" grinding="1.2" chance="1.25" power="0.85" durability="56000" >
+    <item name="itemFlint"/>
+  </grindingball>
+  <grindingball name="Dark Steel Ball" grinding="1.35" chance="2.00" power="0.7" durability="357000" >
+    <item name="ballDarkSteel"/>
+  </grindingball>
+  <grindingball name="Electrical Steel Ball" grinding="1.2" chance="1.65" power="0.8" durability="100000" >
+    <item name="ballElectricalSteel"/>
+  </grindingball>
+  <grindingball name="Energetic Alloy Ball" grinding="1.6" chance="1.1" power="1.1" durability="192000" >
+    <item name="ballEnergeticAlloy"/>
+  </grindingball>
+  <grindingball name="Vibrant Alloy Ball" grinding="1.75" chance="1.35" power="1.35" durability="216000" >
+    <item name="ballVibrantAlloy"/>
+  </grindingball>
+  <grindingball name="Redstone Alloy Ball" grinding="1.00" chance="1.00" power="0.35" durability="171000" >
+    <item name="ballRedstoneAlloy"/>
+  </grindingball>
+  <grindingball name="Conductive Iron Ball" grinding="1.35" chance="1.00" power="1.0" durability="80000" >
+    <item name="ballConductiveIron"/>
+  </grindingball>
+  <grindingball name="Pulsating Iron Ball" grinding="1.0" chance="1.85" power="1.0" durability="200000" >
+    <item name="ballPulsatingIron"/>
+  </grindingball>
+  <grindingball name="Soularium Ball" grinding="1.2" chance="2.15" power="0.9" durability="177000" >
+    <item name="ballSoularium"/>
+  </grindingball>
+  <grindingball name="End Steel Ball" grinding="1.4" chance="2.4" power="0.7" durability="214000" >
+    <item name="ballEndSteel"/>
+  </grindingball>
+  <grindingball name="Construction Alloy Ball" grinding="1.0" chance="0.33" power="0.25" durability="96000" >
+    <item name="CONSTRUCTION_ALLOY_BALL"/>
+  </grindingball>
+  <grindingball name="Signalum Ball" grinding="1.2" chance="1.65" power="0.35" durability="571000" >
+    <item name="SIGNALUM_BALL"/>
+  </grindingball>
+  <grindingball name="Enderium Ball" grinding="1.65" chance="1.45" power="1.25" durability="360000" >
+    <item name="ENDERIUM_BALL"/>
+  </grindingball>
+  <grindingball name="Lumium Ball" grinding="1.1" chance="2.15" power="0.9" durability="222000" >
+    <item name="LUMIUM_BALL"/>
+  </grindingball>
+  <grindingball name="Crystalline Alloy Ball" grinding="1.8" chance="1.4" power="1.45" durability="304000" >
+    <item name="ballCrystallineAlloy"/>
+  </grindingball>
+  <grindingball name="Melodic Alloy Ball" grinding="2.0" chance="1.45" power="1.55" durability="336000" >
+    <item name="ballMelodicAlloy"/>
+  </grindingball>
+  <grindingball name="Stellar Alloy Ball" grinding="2.3" chance="2.25" power="2.2" durability="1088000" >
+    <item name="ballStellarAlloy"/>
+  </grindingball>
+  <grindingball name="Crystalline Pink Slime Ball" grinding="1.75" chance="1.55" power="1.55" durability="496000" >
+    <item name="ballCrystallinePinkSlime"/>
+  </grindingball>
+  <grindingball name="Vivid Alloy Ball" grinding="1.75" chance="1.35" power="1.35" durability="272000" >
+    <item name="ballVividAlloy"/>
+  </grindingball>
   <!-- Dyes remake -->
   <recipe name="Alloy: Green Dye">
     <alloying energy="2000" exp="0.5">


### PR DESCRIPTION
Many grinding balls in EnderIO are supposed to make SAG Mill faster by reducing the amount of energy needed for recipes, but due to increase in SAG Mill's base RF/t consumption, majority of recipes affected by grinding balls are already done in 1 tick and can't go any lower, which makes many balls be used at significantly faster rate and losing most of their utility.
Also the default durability values (aka how much energy SAG Mill needs to spend before consuming a ball) do not account for increased cost of some EnderIO/Thermal alloys, which makes making grinding balls out of them a waste of time and metal.

This pull request aims to increase the durability of all grinding balls to provide more intended experience and account for increased costs for alloys and energy consumption of SAG Mill. Some balls may still be useless due to their sole utility being faster, but most of them should be lasting as long as they should and be worth to make.

Here's comparison table of durability changes in this PR:

| Material               | Previous durability | Changed durability |
| ---------------------- | ------------------- | ------------------ |
| Fur Ball               | 8000                | 64000              |
| Flint                  | 24000               | 56000              |
| Dark Steel             | 125000              | 357000             |
| Electrical Steel       | 40000               | 100000             |
| Energetic Alloy        | 80000               | 192000             |
| Vibrant Alloy          | 80000               | 216000             |
| Redstone Alloy         | 30000               | 171000             |
| Conductive Iron        | 40000               | 80000              |
| Pulsating Iron         | 100000              | 200000             |
| Soularium              | 80000               | 177000             |
| End Steel              | 75000               | 375000             |
| Iron Alloy             | 12000               | 96000              |
| Signalum               | 100000              | 571000             |
| Enderium               | 120000              | 400000             |
| Lumium                 | 100000              | 222000             |
| Crystalline Alloy      | 80000               | 304000             |
| Melodic Alloy          | 80000               | 840000             |
| Stellar Alloy          | 160000              | 1632000            |
| Crystalline Pink Slime | 80000               | 620000             |
| Vivid Alloy            | 80000               | 598000             |