### PR TITLE
Expand fast mineral sampling

### DIFF
--- a/scripts/do/mineral_sampling.zs
+++ b/scripts/do/mineral_sampling.zs
@@ -1,4 +1,4 @@
-#modloaded zenutils immersiveengineering
+#modloaded zenutils immersiveengineering immersivepetroleum
 #reloadable
 
 /**
@@ -28,8 +28,11 @@
 import crafttweaker.data.IData;
 import crafttweaker.entity.IEntityEquipmentSlot;
 import crafttweaker.event.PlayerInteractBlockEvent;
+import crafttweaker.item.IItemStack;
+
 import native.blusunrize.immersiveengineering.api.tool.ExcavatorHandler;
 import native.blusunrize.immersiveengineering.common.blocks.metal.TileEntitySampleDrill;
+import native.flaxbeard.immersivepetroleum.api.crafting.PumpjackHandler;
 
 val ENERGY_COST = 8000 * 10; // base cost is 8000RF, we make it 10 times bigger as the cost of saving time
 
@@ -74,14 +77,26 @@ events.onPlayerInteractBlock(function (event as PlayerInteractBlockEvent) {
     nativePlayer.chunkCoordX,
     nativePlayer.chunkCoordZ
   );
-    val sample = drill.createCoreSample(
+  var sample = drill.createCoreSample(
     nativeWorld,
     nativePlayer.chunkCoordX,
     nativePlayer.chunkCoordZ,
     worldInfo
+  ) as IItemStack;
+  //attach oil info
+  val oilInfo = PumpjackHandler.getOilWorldInfo(
+    nativeWorld,
+    nativePlayer.chunkCoordX,
+    nativePlayer.chunkCoordZ
   );
+  if (!isNull(oilInfo)) {
+    sample = sample.withTag(sample.tag + {
+      "resType": oilInfo.getType().name,
+      "oil": oilInfo.current
+    });
+  }
 
   // give item, and prevent players from clicking multiple times, because one sample is enough for one chunk
-  player.give(sample.wrapper);
+  player.give(sample);
   player.setCooldown(item, 20);
 });

--- a/scripts/do/mineral_sampling.zs
+++ b/scripts/do/mineral_sampling.zs
@@ -1,4 +1,4 @@
-#modloaded zenutils immersiveengineering immersivepetroleum
+#modloaded zenutils immersiveengineering immersivepetroleum tconevo
 #reloadable
 
 /**
@@ -18,6 +18,13 @@
  *     -the position that the sample represents is the position of Sample Drill
  * -player will be given this sample
  * -the hammer will recive a cooldown of 20 ticks
+ *
+ * mod requirement:
+ * - zenutils: for native java access
+ * - immersiveengineering: provides `Mineral Sample`
+ * - immersivepetroleum: for oil support
+ * - tconevo: allows attaching energy to TCon tools, change this if energy consuming method
+ * is altered/removed in the future
  *
  * @author ZZZank
  *

--- a/scripts/do/mineral_sampling.zs
+++ b/scripts/do/mineral_sampling.zs
@@ -34,7 +34,36 @@ import native.blusunrize.immersiveengineering.api.tool.ExcavatorHandler;
 import native.blusunrize.immersiveengineering.common.blocks.metal.TileEntitySampleDrill;
 import native.flaxbeard.immersivepetroleum.api.crafting.PumpjackHandler;
 
+import scripts.jei.crafting_hints;
+
 val ENERGY_COST = 8000 * 10; // base cost is 8000RF, we make it 10 times bigger as the cost of saving time
+
+// Recipe hint
+val ENERGY_FULL_EXAMPLE = 100000; //must be no smaller than `ENERGY_COST` to prevent display error
+crafting_hints.addInsOutsCatl(
+  [
+    <tconstruct:hammer>.withTag({
+      FluxedEnergyMax: ENERGY_FULL_EXAMPLE, 
+      Traits: ["tconevo.fluxed"], 
+      Modifiers: [
+        {identifier: "tconevo.fluxed", color: 11091771, level: 1, modifierUsed: 1 as byte}
+      ], 
+      FluxedEnergy: ENERGY_FULL_EXAMPLE
+    })
+  ],
+  [
+    <tconstruct:hammer>.withTag({
+      FluxedEnergyMax: ENERGY_FULL_EXAMPLE, 
+      Traits: ["tconevo.fluxed"], 
+      Modifiers: [
+        {identifier: "tconevo.fluxed", color: 11091771, level: 1, modifierUsed: 1 as byte}
+      ], 
+      FluxedEnergy: ENERGY_FULL_EXAMPLE - ENERGY_COST
+    }),
+    <immersiveengineering:coresample>
+  ],
+  <immersiveengineering:metal_device1:7>
+);
 
 events.onPlayerInteractBlock(function (event as PlayerInteractBlockEvent) {
   val player = event.player;

--- a/scripts/jei/crafting_hints.zs
+++ b/scripts/jei/crafting_hints.zs
@@ -167,32 +167,3 @@ scripts.jei.requious.add(<assembly:crafting_hints>, { [
   <exnihilocreatio:block_barrel0> | <exnihilocreatio:block_barrel1>, null, null, null, null,
   Bucket('milk'), <minecraft:brown_mushroom> | <minecraft:red_mushroom>,
 ]: [<entity:minecraft:slime>.asStack(), <minecraft:slime>] });
-
-// general mineral sampling
-add1to1(<immersiveengineering:metal_device1:7>, <immersiveengineering:coresample>);
-
-// Fast Mineral Sampling, see scripts/do/mineral_sampling.zs
-addInsOutsCatl(
-  [
-    <tconstruct:hammer>.withTag({
-      FluxedEnergyMax: 100000, 
-      Traits: ["tconevo.fluxed"], 
-      Modifiers: [
-        {identifier: "tconevo.fluxed", color: 11091771, level: 1, modifierUsed: 1 as byte}
-      ], 
-      FluxedEnergy: 100000
-    })
-  ],
-  [
-    <tconstruct:hammer>.withTag({
-      FluxedEnergyMax: 100000, 
-      Traits: ["tconevo.fluxed"], 
-      Modifiers: [
-        {identifier: "tconevo.fluxed", color: 11091771, level: 1, modifierUsed: 1 as byte}
-      ], 
-      FluxedEnergy: 100000 - 8000 * 10
-    }),
-    <immersiveengineering:coresample>
-  ],
-  <immersiveengineering:metal_device1:7>
-);

--- a/scripts/jei/crafting_hints.zs
+++ b/scripts/jei/crafting_hints.zs
@@ -167,3 +167,35 @@ scripts.jei.requious.add(<assembly:crafting_hints>, { [
   <exnihilocreatio:block_barrel0> | <exnihilocreatio:block_barrel1>, null, null, null, null,
   Bucket('milk'), <minecraft:brown_mushroom> | <minecraft:red_mushroom>,
 ]: [<entity:minecraft:slime>.asStack(), <minecraft:slime>] });
+
+// General Mineral Sampling
+add1to1(
+  <immersiveengineering:metal_device1:7>,
+  <immersiveengineering:coresample>
+);
+
+// Fast Mineral Sampling, see scripts/do/mineral_sampling.zs
+addInsOutsCatl(
+  [
+    <tconstruct:hammer>.withTag({
+      FluxedEnergyMax: 100000, 
+      Traits: ["tconevo.fluxed"], 
+      Modifiers: [
+        {identifier: "tconevo.fluxed", color: 11091771, level: 1, modifierUsed: 1 as byte}
+      ], 
+      FluxedEnergy: 100000
+    })
+  ],
+  [
+    <tconstruct:hammer>.withTag({
+      FluxedEnergyMax: 100000, 
+      Traits: ["tconevo.fluxed"], 
+      Modifiers: [
+        {identifier: "tconevo.fluxed", color: 11091771, level: 1, modifierUsed: 1 as byte}
+      ], 
+      FluxedEnergy: 100000 - 8000 * 10
+    }),
+    <immersiveengineering:coresample>
+  ],
+  <immersiveengineering:metal_device1:7>
+);

--- a/scripts/jei/crafting_hints.zs
+++ b/scripts/jei/crafting_hints.zs
@@ -171,9 +171,6 @@ scripts.jei.requious.add(<assembly:crafting_hints>, { [
 // general mineral sampling
 add1to1(<immersiveengineering:metal_device1:7>, <immersiveengineering:coresample>);
 
-// mineral sampling via Portable Drill
-add1to1(<portabledrill:portable_drill>, <immersiveengineering:coresample>);
-
 // Fast Mineral Sampling, see scripts/do/mineral_sampling.zs
 addInsOutsCatl(
   [

--- a/scripts/jei/crafting_hints.zs
+++ b/scripts/jei/crafting_hints.zs
@@ -168,11 +168,11 @@ scripts.jei.requious.add(<assembly:crafting_hints>, { [
   Bucket('milk'), <minecraft:brown_mushroom> | <minecraft:red_mushroom>,
 ]: [<entity:minecraft:slime>.asStack(), <minecraft:slime>] });
 
-// General Mineral Sampling
-add1to1(
-  <immersiveengineering:metal_device1:7>,
-  <immersiveengineering:coresample>
-);
+// general mineral sampling
+add1to1(<immersiveengineering:metal_device1:7>, <immersiveengineering:coresample>);
+
+// mineral sampling via Portable Drill
+add1to1(<portabledrill:portable_drill>, <immersiveengineering:coresample>);
 
 // Fast Mineral Sampling, see scripts/do/mineral_sampling.zs
 addInsOutsCatl(

--- a/scripts/mods/immersiveengineering.zs
+++ b/scripts/mods/immersiveengineering.zs
@@ -488,16 +488,6 @@ craft.remake(<immersivepetroleum:stone_decoration> * 8, [
   D: LiquidIngr('water'),
 });
 
-// [Portable_Drill] from [Bedrock_Miner][+2]
-craft.remake(<portabledrill:portable_drill>, ['pretty',
-  '╱ B ╱',
-  '  |  ',
-  '  |  '], {
-  '╱': <ore:stickSteel>,                 // Steel Rod
-  'B': <bedrockores:bedrock_miner>,      // Bedrock Miner
-  '|': <immersiveengineering:coresample>, // Core Sample
-});
-
 // Forge hammer from IC2 harder to craft, so everyone used IE hammer
 // This change will force players to use Forge Hammer for making plates
 // [Engineer's_Hammer] from [Iron_Hammer_Head][+1]

--- a/scripts/mods/immersiveengineering.zs
+++ b/scripts/mods/immersiveengineering.zs
@@ -6,11 +6,15 @@ import crafttweaker.liquid.ILiquidStack;
 import crafttweaker.potions.IPotionEffect;
 import mods.alfinivia.ImmersiveEngineering.addChemthrowerEffect;
 import mods.alfinivia.ImmersiveEngineering.addRailgunBullet;
+import scripts.jei.crafting_hints;
 
 recipes.remove(<immersiveengineering:material:1>);
 recipes.remove(<immersiveengineering:material:2>);
 recipes.remove(<immersiveengineering:material:3>);
 Purge(<immersiveengineering:material:24>).ores([<ore:dustSaltpeter>, <ore:dustNiter>]);
+
+// Recipe hint for mineral sampling
+crafting_hints.add1to1(<immersiveengineering:metal_device1:7>, <immersiveengineering:coresample>);
 
 // Fix IC2 block
 val UI = <ore:ingotUranium>;

--- a/scripts/mods/portabledrill.zs
+++ b/scripts/mods/portabledrill.zs
@@ -1,0 +1,16 @@
+#modloaded portabledrill
+
+import scripts.jei.crafting_hints;
+
+// [Portable_Drill] from [Bedrock_Miner][+2]
+craft.remake(<portabledrill:portable_drill>, ['pretty',
+  '╱ B ╱',
+  '  |  ',
+  '  |  '], {
+  '╱': <ore:stickSteel>,                 // Steel Rod
+  'B': <bedrockores:bedrock_miner>,      // Bedrock Miner
+  '|': <immersiveengineering:coresample>, // Core Sample
+});
+
+// Recipe hint for mineral sampling via Portable Drill
+crafting_hints.add1to1(<portabledrill:portable_drill>, <immersiveengineering:coresample>);


### PR DESCRIPTION
This PR:
- makes samples generated by Fast Mineral Sampling includes oil information, finally in line with what PortableDrills and normal sampling method will produce.
- adds recipes hints for three sampling methods:
    - Sample Drill
    - Fast Mineral Sampling
    - Portable Drill

example:
(I forgot to change my lang to en_us, but in a nutshell, recipe hints are correct, and I successfully got a sample indicating `bauxite` aka `aluminum ore`, and `13,803,000mB Oil`)

https://github.com/user-attachments/assets/a90e72b0-b1cc-42a6-a7b6-458241ea62fc

