### PR TITLE
fix freeze on startup on hammerlib

### DIFF
--- a/scripts/mixin/hammercore.zs
+++ b/scripts/mixin/hammercore.zs
@@ -1,0 +1,18 @@
+#modloaded hammercore
+#loader mixin
+
+import java.lang.Class;
+import org.apache.logging.log4j.Logger;
+import com.zeitheron.hammercore.utils.CommonMessages;
+import com.zeitheron.hammercore.utils.CommonMessages.CheckResult;
+
+#mixin {targets: ["com.zeitheron.hammercore.utils.CommonMessages"]}
+zenClass MixinCommonMessages {
+
+    #mixin static
+    #mixin overwrite
+    function printMessageOnIllegalRedistribution(modClass as Class, log as Logger, modName as String, downloadUrl as String) as CheckResult {
+        // stopmodrepost.org have some troubles in Russia
+        return CheckResult.OK;
+    }
+}


### PR DESCRIPTION
recently in Russia we have unstable situation with cloudflare so sites like stopmodrepost.org are unreachable.
hammerlib checks on startup ["has this mod been downloaded in illegal resource"](https://github.com/dragon-forge/HammerLib/blob/1.12.2/src/main/java/com/zeitheron/hammercore/utils/java/io/win32/ModSourceAdapter.java#L148)

basically if `HttpRequest.get("https://api.stopmodreposts.org/minecraft/sites.json")` does not respond it freezes minecraft and **you can not run the game without any kinf of bypass services**.

so can we just remove this check on `printMessageOnIllegalRedistribution` method? because we know that all mods are from curseforge