### PR TITLE
Mithminite scythe reballance

### DIFF
--- a/scripts/do/mithminite_scythe.zs
+++ b/scripts/do/mithminite_scythe.zs
@@ -292,12 +292,10 @@ function dracoBreath(target as IEntityLivingBase, lvl as int) as void {
     'Age'          : 0,
     'Duration'     : 140,
   });
-  val ball as IEntity = <entity:iceandfire:dragonfirecharge>.spawnEntity(target.world, crafttweaker.util.Position3f.create(target.x, target.y + 4, target.z));
-  ball.hasNoGravity = true;
-  ball.updateNBT({
-    'Fire' : 20 as short,
-    'power': [0.0,-0.01,0.0],
-  });
+
+  (target.world.native as WorldServer).spawnParticle(EnumParticleTypes.FLAME,
+      target.x, entityEyeHeight(target), target.z, 100, 0.5, 0, 0.5, 0.1, 0);
+
 
   val listAllEntities = target.world.getEntities();
 

--- a/scripts/do/mithminite_scythe.zs
+++ b/scripts/do/mithminite_scythe.zs
@@ -802,9 +802,23 @@ function scytheEffectElemental(scythe as IEntity, target as IEntityLivingBase, p
   if (augments has 'metallum')     metallumPrison(target);
   if (augments has 'terra')        terraQuickSand(target, colorCount[5]);
   // CONTROL ASPECTS
-  if (augments has 'fluctus')      fluctusWave(target, colorCount[1]);
-  if (augments has 'aer')          aerTornado(scythe, colorCount[4]);
-  if (augments has 'vacuos')       vacuosHole(scythe, target, colorCount[0]);
+  var cooldown = 0;
+  if(!player.native.cooldownTracker.hasCooldown(<thaumadditions:mithminite_scythe>.native.getItem())){
+    if (augments has 'fluctus'){
+      fluctusWave(target, colorCount[1]);
+      cooldown += 200;
+    }      
+    if (augments has 'aer'){
+      aerTornado(scythe, colorCount[4]);
+      cooldown += 200;
+    }
+    if (augments has 'vacuos'){
+      vacuosHole(scythe, target, colorCount[0]);
+      cooldown += 200;
+    } 
+    if(cooldown != 0) player.native.cooldownTracker.setCooldown(<thaumadditions:mithminite_scythe>.native.getItem(), cooldown);
+  }
+  
   // EFFECT ASPECTS
   if (augments has 'amogus')       amogusVent(scythe, target);
   if (augments has 'auram')        auramVisAdd(scythe, colorCount[6]);

--- a/scripts/do/mithminite_scythe.zs
+++ b/scripts/do/mithminite_scythe.zs
@@ -172,8 +172,8 @@ function amogusVent(scythe as IEntity, target as IEntityLivingBase) as void {
   scythe.setDead();
 }
 
-function aquaSplash(target as IEntityLivingBase, lvl as int) as void {
-  val water = <liquid:water>.definition.block.definition.getStateFromMeta(1);
+function aquaSplash(target as IEntityLivingBase, lvl as int, isMortuus as bool) as void {
+  val water = isMortuus ? <liquid:fluid_quicksilver>.definition.block.definition.getStateFromMeta(1) : <liquid:water>.definition.block.definition.getStateFromMeta(1);
   val x = target.getX() > 0 ? target.getX() as int : target.getX() as int - 1;
   val y = target.getY() as float;
   val z = target.getZ() > 0 ? target.getZ() as int : target.getZ() as int - 1;
@@ -798,7 +798,7 @@ function vitreusCrystalize(scythe as IEntity, target as IEntityLivingBase, dmg a
 
 function scytheEffectElemental(scythe as IEntity, target as IEntityLivingBase, player as IPlayer, augments as string[], dmg as double, colorCount as int[]) as void {
   // CREATION ASPECTS
-  if (augments has 'aqua')         aquaSplash(target, colorCount[2]);
+  if (augments has 'aqua')         aquaSplash(target, colorCount[2], augments has 'mortuus');
   if (augments has 'bestia')       bestiaHunt(scythe, target);
   if (augments has 'metallum')     metallumPrison(target);
   if (augments has 'terra')        terraQuickSand(target, colorCount[5]);

--- a/scripts/do/mithminite_scythe.zs
+++ b/scripts/do/mithminite_scythe.zs
@@ -1126,7 +1126,5 @@ events.onProjectileImpactArrow(function (e as crafttweaker.event.ProjectileImpac
 }, 200);
 
 events.register(function (e as crafttweaker.event.LootingLevelEvent) {
-  print(e.entityLivingBase.nbt);
   if(!isNull(e.entityLivingBase.nbt.ForgeData.scytheExtraLooting)) e.lootingLevel = e.lootingLevel * 2 + e.entityLivingBase.nbt.ForgeData.scytheExtraLooting;
-  print(e.lootingLevel);
 }, EventPriority.low());

--- a/scripts/do/mithminite_scythe.zs
+++ b/scripts/do/mithminite_scythe.zs
@@ -19,6 +19,7 @@ import mods.ctutils.entity.Experience;
 import native.net.minecraft.util.EnumParticleTypes;
 import native.net.minecraft.world.WorldServer;
 import native.org.zeith.thaumicadditions.entity.EntityMithminiteScythe;
+import mods.zenutils.EventPriority;
 
 /*
 "aer"           : C Tornado, pulls nearby enemies (motion)
@@ -811,7 +812,10 @@ function scytheEffectElemental(scythe as IEntity, target as IEntityLivingBase, p
   if (augments has 'auram')        auramVisAdd(scythe, colorCount[6]);
   if (augments has 'caeles')       caelesAstralExp(scythe, colorCount[2]);
   if (augments has 'cognitio')     cognitioExperienceBlessing(scythe, target, colorCount[4]);
-  if (augments has 'desiderium')   desideriumDisarm(target);
+  if (augments has 'desiderium'){
+    target.	setNBT({scytheExtraLooting: colorCount[4]});
+    if (augments has 'praemunio')  desideriumDisarm(target);
+  }
   if (augments has 'draco')        dracoBreath(target, colorCount[2]);
   if (augments has 'exanimis')     exanimisPoison(target, colorCount[5]);
   if (augments has 'exitium')      exitiumExplosion(target, colorCount[1]);
@@ -963,7 +967,7 @@ events.onEntityJoinWorld(function (e as crafttweaker.event.EntityJoinWorldEvent)
   scythe.motionZ = scythe.motionZ * 10;
 });
 
-events.onProjectileImpactThrowable(function (e as crafttweaker.event.ProjectileImpactThrowableEvent) {
+events.register(function (e as crafttweaker.event.ProjectileImpactThrowableEvent) {
   val scythe = e.entity;
   val rayTrace = e.rayTrace;
   if (isNull(scythe)
@@ -1039,7 +1043,7 @@ events.onProjectileImpactThrowable(function (e as crafttweaker.event.ProjectileI
 
   rayTrace.entity.attackEntityFrom(damageSource, dmg);
    
-});
+}, EventPriority.high());
 
 events.onProjectileImpactFireball(function (e as crafttweaker.event.ProjectileImpactFireballEvent) {
   val projectile = e.entity;
@@ -1108,3 +1112,9 @@ events.onProjectileImpactArrow(function (e as crafttweaker.event.ProjectileImpac
   if(entity.world.remote) return;
   entity.setDead();
 }, 200);
+
+events.register(function (e as crafttweaker.event.LootingLevelEvent) {
+  print(e.entityLivingBase.nbt);
+  if(!isNull(e.entityLivingBase.nbt.ForgeData.scytheExtraLooting)) e.lootingLevel = e.lootingLevel * 2 + e.entityLivingBase.nbt.ForgeData.scytheExtraLooting;
+  print(e.lootingLevel);
+}, EventPriority.low());

--- a/scripts/do/mithminite_scythe.zs
+++ b/scripts/do/mithminite_scythe.zs
@@ -1008,7 +1008,7 @@ events.register(function (e as crafttweaker.event.ProjectileImpactThrowableEvent
   if (!scythe.native instanceof EntityMithminiteScythe) return;
 
   var dmg = 100.0;
-  val damageSource = crafttweaker.damage.IDamageSource.createIndirectDamage('mithminiteScythe', scythe, player);
+  var damageSource = crafttweaker.damage.IDamageSource.createEntityDamage('mithminiteScythe', player);
   if(augments has 'praemunio') damageSource.setDamageBypassesArmor();
 
   // AVERSIO | PRAECANTIATIO | PRAEMUNIO | VITIUM

--- a/scripts/mixin/thaumicadditions.zs
+++ b/scripts/mixin/thaumicadditions.zs
@@ -1,0 +1,13 @@
+#modloaded thaumadditions
+#loader mixin
+
+import native.net.minecraft.util.math.RayTraceResult;
+import native.net.minecraft.entity.projectile.EntityThrowable;
+
+#mixin {targets: "org.zeith.thaumicadditions.entity.EntityMithminiteScythe"}
+zenClass MixinEntityMithminiteScythe extends EntityThrowable {
+    #mixin Overwrite
+    function func_70184_a(result as RayTraceResult) as void {
+        return;
+    }
+}


### PR DESCRIPTION
# Mithminite scythe changes:
> - Fixed scythe projectiles dealing only 12 damage on hit
> - Changed type of damage to work on some entities like: Ender dragon, End crystal, Enderman
> - Added cooldown mechanic (affected aspects: `Aer, Fluctus, Vacuos`)
> - Rework `Aer` aspect - now tornado is timed effect and it moves in random direction
> - Added `Aqua + Mortuus` combo - uses quicksilver instead of water
> - Replaced clumsy ball from `Draco` with particles
> - Looting works on scythe
> - `Desiderium` now multiplies by 2 looting effect from scythe + yellow color count; armor droping effect replaced by `Desiderium + Praemunio`

# Technical changes:
> If possible, removed `.definition`

# Tests (singleplayer only):
- if there are any errors using changed and old seals effects

# Further info
- I still want to make few addition to thaumonomicon (describe combos and add ICON with i saw in other mod and would love to add this)
- I have some "unbalanced" crazy idea to make spawn mana storm if scythe have `aer, vacuos, fluctus and mana` aspects
- I may got some further ideas, for now i created this sheet <https://docs.google.com/spreadsheets/d/1csr9E0ZUXlYOZF-1WA_ky_O7P7qn7_XT6lwLxMMG2Pc/edit?usp=sharing>, if you (or someone reading this) have any suggestions, i would be glad to hear! - even about rebalancing some things