### PR TITLE
Reduce energy consumption of Cyclic Enchanter to make it behave less wacky

### DIFF
--- a/config/cyclicmagic.cfg
+++ b/config/cyclicmagic.cfg
@@ -2800,7 +2800,7 @@ cyclicmagic {
         I:block_disenchanter=99
 
         # Fuel/Energy/RF cost to run machine [range: 0 ~ 500000, default: 900]
-        I:block_enchanter=3000
+        I:block_enchanter=5000
 
         # Experience fluid cost per damage unit [range: 1 ~ 1000, default: 100]
         I:block_enchanter_xpjuice=100

--- a/config/cyclicmagic.cfg
+++ b/config/cyclicmagic.cfg
@@ -2800,7 +2800,7 @@ cyclicmagic {
         I:block_disenchanter=99
 
         # Fuel/Energy/RF cost to run machine [range: 0 ~ 500000, default: 900]
-        I:block_enchanter=64000
+        I:block_enchanter=3000
 
         # Experience fluid cost per damage unit [range: 1 ~ 1000, default: 100]
         I:block_enchanter_xpjuice=100


### PR DESCRIPTION
As described in #533 , the behaviour of Cyclic Enchanter is quite wacky. Except for the first operation, where enchanting an item requires 64000 RF, enchanting an item will generally require 64000*22=1408000 RF. And massive energy consumption itself is not the biggest problem.

Due to Cyclic's design, the 1408000 RF is split into 22 cycles, each consuming 64000 RF **at once**. By coincidence, the Enchanter itself can only store 64000 RF at most, which means that whenever an Enchanter is fully charged, all its energy will be consumed by a cycle at once. This behaviour is wacky and can easily make users consider the Enchanter as "broken".

So this PR reduced the energy consumption of Cyclic Enchanter, so that:
- Energy is consumed in a more "continuous" manner
- The total energy cost is not too ridiculous for players who can craft it, who are usually at a relatively early stage of gameplay

Fixes #533 