### PR TITLE
Fix custom mineral sampling

### DIFF
--- a/scripts/do/mineral_sampling.zs
+++ b/scripts/do/mineral_sampling.zs
@@ -118,14 +118,14 @@ events.onPlayerInteractBlock(function (event as PlayerInteractBlockEvent) {
     nativePlayer.chunkCoordX,
     nativePlayer.chunkCoordZ,
     worldInfo
-  ) as IItemStack;
+  ).wrapper;
   //attach oil info
   val oilInfo = PumpjackHandler.getOilWorldInfo(
     nativeWorld,
     nativePlayer.chunkCoordX,
     nativePlayer.chunkCoordZ
   );
-  if (!isNull(oilInfo)) {
+  if (!isNull(oilInfo) && !isNull(oilInfo.getType())) {
     sample = sample.withTag(sample.tag + {
       "resType": oilInfo.getType().name,
       "oil": oilInfo.current


### PR DESCRIPTION
Fixed issue:
- `as IItemStack` will cause a class cast error. Could be a ZenUtils problem, but `.wrapper` is still working.
- sampling in a chunk with no oil will cause NPE