### PR TITLE
Extended Chisel support for Sonar Core blocks

### DIFF
--- a/scripts/mods/chisel.zs
+++ b/scripts/mods/chisel.zs
@@ -53,8 +53,9 @@ addVariation('soulstone_slab', <mysticalagriculture:soulstone_slab>);
 addVariation('sonar_dirt', <sonarcore:reinforceddirtblock>);
 addVariation('sonar_dirt', <sonarcore:reinforceddirtbrick>);
 
-addVariation('sonar_normal', <sonarcore:reinforcedstoneblock>);
-addVariation('sonar_normal', <sonarcore:reinforcedstonebrick>);
+addVariation('sonar_stone', <sonarcore:reinforcedstoneblock>);
+addVariation('sonar_stone', <sonarcore:reinforcedstonebrick>);
+
 addVariation('sonar_normal', <sonarcore:stablestone_normal>);
 addVariation('sonar_normal', <sonarcore:stablestonerimmed_normal>);
 addVariation('sonar_normal', <sonarcore:stablestoneblackrimmed_normal>);


### PR DESCRIPTION
Small gripe I have with Sonar Core's blocks are that they barely have any Chisel support. So here's a fix to that.

- Reinforced Stone, Reinforced Stone Brick, Stable Stone (Rimmed, Black Rimmed), Stable Stone Plain (Rimmed, Black Rimmed) merged into one group
<img width="698" height="778" alt="2025-11-02_20 15 10" src="https://github.com/user-attachments/assets/e162b23b-3e65-46cd-bb42-6c377531f03b" />


- Reinforced Dirt, Reinforced Dirt Brick
<img width="698" height="778" alt="2025-11-02_20 26 47" src="https://github.com/user-attachments/assets/4040288d-c845-4477-bea5-d701a24ee99c" />


- Stable Glass, Clear Stable Glass added to generic 'glass' group, since their crafting recipe is just a conversion from generic glass
<img width="698" height="778" alt="2025-11-02_20 16 05" src="https://github.com/user-attachments/assets/96c6f1b5-5671-43ca-9e21-35f9c49c5cbf" />
