### PR TITLE
Fix RFTools dimensions actually being accessable in skyblock mode

### DIFF
--- a/scripts/category/dimensions.zs
+++ b/scripts/category/dimensions.zs
@@ -77,7 +77,7 @@ function isAllowedDim(dimId as int) as bool {
   if (allowedDims has dimId) return true;
   val providerType = native.net.minecraftforge.common.DimensionManager.getProviderType(dimId);
   if(isNull(providerType)) return false;
-  return toString(providerType.getId()) == 'rftools_dimension';
+  return toString(providerType.getName()) == 'rftools_dimension';
 }
 
 events.onEntityTravelToDimension(function (e as crafttweaker.event.EntityTravelToDimensionEvent) {


### PR DESCRIPTION
The name of the RFTools dimension provider was being compared to the id of the dimension provider. This resulted in the check always failing, even if the dimension the player traveled to was in fact a RFTools dimension.
<img width="1919" height="1035" alt="image" src="https://github.com/user-attachments/assets/6d2cc3c3-5d20-49ab-b3a4-c55362724420" />


This might have been missed in testing as creative mode dimension teleport is allowed in skyblock.