### PR TITLE
Fix Bedrock Ores - FluidLogging crash on server

### DIFF
--- a/scripts/mixin/bedrockores_server.zs
+++ b/scripts/mixin/bedrockores_server.zs
@@ -4,7 +4,6 @@
 
 import mixin.Operation;
 import native.net.minecraft.util.BlockRenderLayer;
-import native.net.minecraftforge.fml.common.FMLCommonHandler;
 
 #mixin {targets: "li.cil.bedrockores.common.block.BlockBedrockOre"}
 zenClass MixinBlockBedrockOre {
@@ -28,3 +27,4 @@ zenClass MixinBlockBedrockOre {
         return null;
     }
 }
+


### PR DESCRIPTION
Fixes crash when fluids interact with bedrock ores on the server. 

The cause for the crash is that FluidLogging uses their own block accessor when getting the actual block state. Bedrock ores expects this to always be a world and if it isn't it assumes the code to be running on the client triggering the crash by calling a client only method on the server. The fix is relatively simple, just bypass the client only method and return null like Bedrock Ores expects when it's not rendering.