### PR TITLE
Make VICE a bauble

### DIFF
--- a/scripts/mixin/vaultopic.zs
+++ b/scripts/mixin/vaultopic.zs
@@ -72,8 +72,7 @@ zenClass MixinVICEPlayerHasItem {
         }
 
         val baubles = BaublesApi.getBaubles(player);
-        val max = baubles.getSizeInventory() - 1;
-        for i in 0 .. max {
+        for i in 0 .. baubles.getSizeInventory() {
             val stack = baubles.getStackInSlot(i);
             if (!isNull(stack) && stack.getItem() == item) return true;
         }

--- a/scripts/mixin/vaultopic.zs
+++ b/scripts/mixin/vaultopic.zs
@@ -63,11 +63,11 @@ zenClass MixinVICEPlayerHasItem {
     #mixin Overwrite
     function playerHasItem(player as native.net.minecraft.entity.player.EntityPlayer, item as native.net.minecraft.item.Item) as bool {
 
-        for stack in player.field_71071_by.field_184439_c {
+        for stack in player.inventory.offHandInventory {
             if (!isNull(stack) && stack.getItem() == item) return true;
         }
 
-        for stack in player.field_71071_by.field_70462_a {
+        for stack in player.inventory.mainInventory {
             if (!isNull(stack) && stack.getItem() == item) return true;
         }
 

--- a/scripts/mixin/vaultopic.zs
+++ b/scripts/mixin/vaultopic.zs
@@ -6,6 +6,7 @@ import native.baubles.api.BaublesApi;
 import native.baubles.api.IBauble;
 import native.net.minecraft.item.ItemStack;
 import native.wolforce.vaultopic.ItemVICE;
+import native.wolforce.vaultopic.ItemVIEW;
 import native.wolforce.vaultopic.client.Keybinds;
 
 #mixin {targets: "wolforce.vaultopic.ItemVICE"}
@@ -25,6 +26,30 @@ zenClass MixinVICEInventorySearch {
         for i in 0 .. baubles.getSizeInventory() {
             val stack = baubles.getStackInSlot(i);
             if (!isNull(stack) && stack.getItem() instanceof ItemVICE) {
+                info.setReturnValue(true);
+                return;
+            }
+        }
+    }
+}
+
+#mixin {targets: "wolforce.vaultopic.ItemVIEW"}
+zenClass MixinItemVIEWAsBauble extends IBauble {
+
+    function getBaubleType(stack as ItemStack) as BaubleType {
+        return BaubleType.TRINKET;
+    }
+
+}
+
+#mixin {targets: "wolforce.vaultopic.client.Keybinds"}
+zenClass MixinVIEWInventorySearch {
+    #mixin Inject {method: "canView", at: {value: "HEAD"}, cancellable: true}
+    function canViceWithBaubles(player as native.net.minecraft.client.entity.EntityPlayerSP, info as mixin.CallbackInfoReturnable) as void {
+        val baubles = BaublesApi.getBaubles(player);
+        for i in 0 .. baubles.getSizeInventory() {
+            val stack = baubles.getStackInSlot(i);
+            if (!isNull(stack) && stack.getItem() instanceof ItemVIEW) {
                 info.setReturnValue(true);
                 return;
             }

--- a/scripts/mixin/vaultopic.zs
+++ b/scripts/mixin/vaultopic.zs
@@ -1,0 +1,58 @@
+#modloaded baubles vaultopic
+#loader mixin
+
+import native.baubles.api.BaubleType;
+import native.baubles.api.BaublesApi;
+import native.baubles.api.IBauble;
+import native.net.minecraft.item.ItemStack;
+import native.wolforce.vaultopic.ItemVICE;
+import native.wolforce.vaultopic.client.Keybinds;
+
+#mixin {targets: "wolforce.vaultopic.ItemVICE"}
+zenClass MixinItemVICEAsBauble extends IBauble {
+
+    function getBaubleType(stack as ItemStack) as BaubleType {
+        return BaubleType.TRINKET;
+    }
+
+}
+
+#mixin {targets: "wolforce.vaultopic.client.Keybinds"}
+zenClass MixinVICEInventorySearch {
+    #mixin Inject {method: "canVice", at: {value: "HEAD"}, cancellable: true}
+    function canViceWithBaubles(player as native.net.minecraft.client.entity.EntityPlayerSP, info as mixin.CallbackInfoReturnable) as void {
+        val baubles = BaublesApi.getBaubles(player);
+        for i in 0 .. baubles.getSizeInventory() {
+            val stack = baubles.getStackInSlot(i);
+            if (!isNull(stack) && stack.getItem() instanceof ItemVICE) {
+                info.setReturnValue(true);
+                return;
+            }
+        }
+    }
+}
+
+#mixin {targets: "wolforce.vaultopic.VU"}
+zenClass MixinVICEPlayerHasItem {
+    #mixin Static
+    #mixin Overwrite
+    function playerHasItem(player as native.net.minecraft.entity.player.EntityPlayer, item as native.net.minecraft.item.Item) as bool {
+
+        for stack in player.field_71071_by.field_184439_c {
+            if (!isNull(stack) && stack.getItem() == item) return true;
+        }
+
+        for stack in player.field_71071_by.field_70462_a {
+            if (!isNull(stack) && stack.getItem() == item) return true;
+        }
+
+        val baubles = BaublesApi.getBaubles(player);
+        val max = baubles.getSizeInventory() - 1;
+        for i in 0 .. max {
+            val stack = baubles.getStackInSlot(i);
+            if (!isNull(stack) && stack.getItem() == item) return true;
+        }
+
+        return false;
+    }
+}

--- a/scripts/mixin/vaultopic.zs
+++ b/scripts/mixin/vaultopic.zs
@@ -18,8 +18,9 @@ zenClass MixinItemVICEAsBauble extends IBauble {
 
 }
 
+//Client side logic searching player inventory for VICE item
 #mixin {targets: "wolforce.vaultopic.client.Keybinds"}
-zenClass MixinVICEInventorySearch {
+zenClass MixinVICEInventorySearchForClient {
     #mixin Inject {method: "canVice", at: {value: "HEAD"}, cancellable: true}
     function canViceWithBaubles(player as native.net.minecraft.client.entity.EntityPlayerSP, info as mixin.CallbackInfoReturnable) as void {
         val baubles = BaublesApi.getBaubles(player);
@@ -42,8 +43,9 @@ zenClass MixinItemVIEWAsBauble extends IBauble {
 
 }
 
+//Client side logic searching player inventory for VIEW item
 #mixin {targets: "wolforce.vaultopic.client.Keybinds"}
-zenClass MixinVIEWInventorySearch {
+zenClass MixinVIEWInventorySearchForClient {
     #mixin Inject {method: "canView", at: {value: "HEAD"}, cancellable: true}
     function canViceWithBaubles(player as native.net.minecraft.client.entity.EntityPlayerSP, info as mixin.CallbackInfoReturnable) as void {
         val baubles = BaublesApi.getBaubles(player);
@@ -57,6 +59,7 @@ zenClass MixinVIEWInventorySearch {
     }
 }
 
+//Server side logic
 #mixin {targets: "wolforce.vaultopic.VU"}
 zenClass MixinVICEPlayerHasItem {
     #mixin Static


### PR DESCRIPTION
V.I.C.E. as a bauble

# What was tested
If vice can be used:
- by right click
- in inventory or in bauble slot by `shift + e`
If vice pull items from nearby containers

As always I couldn't test it on multiplayer server