### PR TITLE
resetplanetsfromXML AR.2.2.7

### DIFF
--- a/config/advRocketry/advancedRocketry.cfg
+++ b/config/advRocketry/advancedRocketry.cfg
@@ -260,7 +260,7 @@ planet {
 
     # Reload planet definitions from config XML on this restart. [default: false]
     B:resetPlanetsFromXML=true
-
+}
 
 "resource collection missions" {
     # Per-mission harvest cap = 64,000 mB × multiplier. Ignored if gasHarvestInfinite=true.

--- a/config/advRocketry/advancedRocketry.cfg
+++ b/config/advRocketry/advancedRocketry.cfg
@@ -139,9 +139,6 @@ general {
     # Allow AR machines to make rods/plates e.g for other mods. May increase load time.
     B:makeMaterialsForOtherMods=false
 
-    # setting this to true will force AR to read from the XML file in the config/advRocketry instead of the local data, intended for use pack developers to ensure updates are pushed through [default: false]
-    B:resetPlanetsFromXML=true
-
     # Allow the cutting machine to turn vanilla wood into planks.
     B:sawMillCutVanillaWood=false
 
@@ -260,7 +257,9 @@ planet {
 
     # Planets must be discovered in the warp controller before being visible
     B:planetsMustBeDiscovered=false
-}
+
+    # Reload planet definitions from config XML on this restart. [default: false]
+    B:resetPlanetsFromXML=true
 
 
 "resource collection missions" {


### PR DESCRIPTION
You have it on true, so keep it on true but move to planet{} where the reset flip actually works correctly