### PR TITLE
Rebalance warp events

### DIFF
--- a/config/warpomania.cfg
+++ b/config/warpomania.cfg
@@ -14,7 +14,7 @@ general {
         B:"Enable Warp Event"=true
 
         # The minimum amount of warp required for this event to occur.
-        I:"Minimum Warp"=200
+        I:"Minimum Warp"=75
 
         # The weight for this event to occur. Lower weight will decrease the event chance.
         I:"Warp Event Weight"=10
@@ -32,7 +32,7 @@ general {
         B:"Enable Warp Event"=true
 
         # The minimum amount of warp required for this event to occur.
-        I:"Minimum Warp"=100
+        I:"Minimum Warp"=20
 
         # The weight for this event to occur. Lower weight will decrease the event chance.
         I:"Warp Event Weight"=10
@@ -50,7 +50,7 @@ general {
         B:"Enable Warp Event"=true
 
         # The minimum amount of warp required for this event to occur.
-        I:"Minimum Warp"=160
+        I:"Minimum Warp"=65
 
         # The weight for this event to occur. Lower weight will decrease the event chance.
         I:"Warp Event Weight"=10
@@ -68,7 +68,7 @@ general {
         B:"Enable Warp Event"=true
 
         # The minimum amount of warp required for this event to occur.
-        I:"Minimum Warp"=200
+        I:"Minimum Warp"=50
 
         # The weight for this event to occur. Lower weight will decrease the event chance.
         I:"Warp Event Weight"=10
@@ -86,7 +86,7 @@ general {
         B:"Enable Warp Event"=true
 
         # The minimum amount of warp required for this event to occur.
-        I:"Minimum Warp"=400
+        I:"Minimum Warp"=200
 
         # The weight for this event to occur. Lower weight will decrease the event chance.
         I:"Warp Event Weight"=10
@@ -104,7 +104,7 @@ general {
         B:"Enable Warp Event"=true
 
         # The minimum amount of warp required for this event to occur.
-        I:"Minimum Warp"=250
+        I:"Minimum Warp"=100
 
         # The weight for this event to occur. Lower weight will decrease the event chance.
         I:"Warp Event Weight"=10
@@ -122,7 +122,7 @@ general {
         B:"Enable Warp Event"=true
 
         # The minimum amount of warp required for this event to occur.
-        I:"Minimum Warp"=90
+        I:"Minimum Warp"=40
 
         # The weight for this event to occur. Lower weight will decrease the event chance.
         I:"Warp Event Weight"=10
@@ -137,10 +137,10 @@ general {
 
     "enderman swarm" {
         # Enables this warp event.
-        B:"Enable Warp Event"=true
+        B:"Enable Warp Event"=false
 
         # The minimum amount of warp required for this event to occur.
-        I:"Minimum Warp"=400
+        I:"Minimum Warp"=200
 
         # The weight for this event to occur. Lower weight will decrease the event chance.
         I:"Warp Event Weight"=10
@@ -158,7 +158,7 @@ general {
         B:"Enable Warp Event"=true
 
         # The minimum amount of warp required for this event to occur.
-        I:"Minimum Warp"=400
+        I:"Minimum Warp"=80
 
         # The weight for this event to occur. Lower weight will decrease the event chance.
         I:"Warp Event Weight"=10
@@ -173,7 +173,7 @@ general {
 
     "firebat swarm" {
         # Enables this warp event.
-        B:"Enable Warp Event"=true
+        B:"Enable Warp Event"=false
 
         # The minimum amount of warp required for this event to occur.
         I:"Minimum Warp"=300
@@ -194,7 +194,7 @@ general {
         B:"Enable Warp Event"=true
 
         # The minimum amount of warp required for this event to occur.
-        I:"Minimum Warp"=100
+        I:"Minimum Warp"=80
 
         # The weight for this event to occur. Lower weight will decrease the event chance.
         I:"Warp Event Weight"=10
@@ -209,7 +209,7 @@ general {
 
     "impending doom - skeletons" {
         # Enables this warp event.
-        B:"Enable Warp Event"=true
+        B:"Enable Warp Event"=false
 
         # The minimum amount of warp required for this event to occur.
         I:"Minimum Warp"=350
@@ -227,7 +227,7 @@ general {
 
     "impending doom - wither skeletons" {
         # Enables this warp event.
-        B:"Enable Warp Event"=true
+        B:"Enable Warp Event"=false
 
         # The minimum amount of warp required for this event to occur.
         I:"Minimum Warp"=400
@@ -263,7 +263,7 @@ general {
 
     "impending doom - zombies" {
         # Enables this warp event.
-        B:"Enable Warp Event"=true
+        B:"Enable Warp Event"=false
 
         # The minimum amount of warp required for this event to occur.
         I:"Minimum Warp"=300
@@ -284,7 +284,7 @@ general {
         B:"Enable Warp Event"=true
 
         # The minimum amount of warp required for this event to occur.
-        I:"Minimum Warp"=100
+        I:"Minimum Warp"=75
 
         # The weight for this event to occur. Lower weight will decrease the event chance.
         I:"Warp Event Weight"=20
@@ -302,7 +302,7 @@ general {
         B:"Enable Warp Event"=true
 
         # The minimum amount of warp required for this event to occur.
-        I:"Minimum Warp"=240
+        I:"Minimum Warp"=40
 
         # The weight for this event to occur. Lower weight will decrease the event chance.
         I:"Warp Event Weight"=10
@@ -320,7 +320,7 @@ general {
         B:"Enable Warp Event"=true
 
         # The minimum amount of warp required for this event to occur.
-        I:"Minimum Warp"=340
+        I:"Minimum Warp"=40
 
         # The weight for this event to occur. Lower weight will decrease the event chance.
         I:"Warp Event Weight"=10
@@ -335,7 +335,7 @@ general {
 
     poison {
         # Enables this warp event.
-        B:"Enable Warp Event"=true
+        B:"Enable Warp Event"=false
 
         # The minimum amount of warp required for this event to occur.
         I:"Minimum Warp"=370
@@ -356,7 +356,7 @@ general {
         B:"Enable Warp Event"=true
 
         # The minimum amount of warp required for this event to occur.
-        I:"Minimum Warp"=200
+        I:"Minimum Warp"=100
 
         # The weight for this event to occur. Lower weight will decrease the event chance.
         I:"Warp Event Weight"=10
@@ -374,7 +374,7 @@ general {
         B:"Enable Warp Event"=true
 
         # The minimum amount of warp required for this event to occur.
-        I:"Minimum Warp"=200
+        I:"Minimum Warp"=50
 
         # The weight for this event to occur. Lower weight will decrease the event chance.
         I:"Warp Event Weight"=10


### PR DESCRIPTION
- Lowered requirements for "silly" warp events
- Disabled (almost all) lethal events - still no wither boss from warp
- Eldritch crab spawn event was kept at high warp level (to allow natural scan in skyblock)
