### PR TITLE
Native Cleanroom Support

### DIFF
--- a/config/relauncher.json
+++ b/config/relauncher.json
@@ -1,0 +1,10 @@
+{
+  "selectedVersion": "0.5.12-alpha",
+  "latestVersion": "0.5.12-alpha",
+  "targetJavaVersion": "J25",
+  "targetVendor": "AZUL_ZULU",
+  "javaPath": "",
+  "args": "-XX:+UseCompactObjectHeaders ",
+  "autoSetup": true,
+  "enableRelauncher": true
+}

--- a/manifest.json
+++ b/manifest.json
@@ -445,6 +445,7 @@
     {"projectID":1504502,"fileID":8001924,"___name":"XNet: Additions"                         ,"downloadUrl":"https://edge.forgecdn.net/files/8001/924/XNetAdditions-0.1.4.jar","required":true},
     {"projectID":1533287,"fileID":8035777,"___name":"ThaumicAPI"                              ,"downloadUrl":"https://edge.forgecdn.net/files/8035/777/thaumicapi-1.0.0.jar","required":true},
     {"projectID":1533544,"fileID":8037355,"___name":"Warp-O-Mania"                            ,"downloadUrl":"https://edge.forgecdn.net/files/8037/355/warpomania-1.0.0.jar","required":true},
-    {"projectID":1535236,"fileID":8053452,"___name":"Tinker's Planner Antique"                ,"downloadUrl":"https://edge.forgecdn.net/files/8053/452/TinkersPlannerAntique-1.12.2-1.0.2.jar","required":true}
+    {"projectID":1535236,"fileID":8053452,"___name":"Tinker's Planner Antique"                ,"downloadUrl":"https://edge.forgecdn.net/files/8053/452/TinkersPlannerAntique-1.12.2-1.0.2.jar","required":true},
+    {"projectID":1214490,"fileID":8073312,"___name":"Cleanroom Relauncher"                    ,"downloadUrl":"https://edge.forgecdn.net/files/8073/312/!cleanroom-relauncher-0.5.0.jar","required":true}
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -421,6 +421,7 @@
     {"projectID":1195285,"fileID":6166729,"___name":"Gadothaumy"                              ,"downloadUrl":"https://edge.forgecdn.net/files/6166/729/Infusion%20Claw%20Mod-1.0.0.jar","required":true},
     {"projectID":1198138,"fileID":8025976,"___name":"RandomComplement"                        ,"downloadUrl":"https://edge.forgecdn.net/files/8025/976/random_complement-1.9.3.jar","required":true},
     {"projectID":1209235,"fileID":7646417,"___name":"AnotherTips"                             ,"downloadUrl":"https://edge.forgecdn.net/files/7646/417/anothertips-1.0.5.jar","required":true},
+    {"projectID":1214490,"fileID":8073312,"___name":"Cleanroom Relauncher"                    ,"downloadUrl":"https://edge.forgecdn.net/files/8073/312/!cleanroom-relauncher-0.5.0.jar","required":true},
     {"projectID":1220460,"fileID":7947648,"___name":"Gnetum"                                  ,"downloadUrl":"https://edge.forgecdn.net/files/7947/648/gnetum-1.4.1.jar","required":true},
     {"projectID":1221029,"fileID":6973315,"___name":"Ender's Modpack Tweaks"                  ,"downloadUrl":"https://edge.forgecdn.net/files/6973/315/endermodpacktweaks-0.5.11.jar","required":true},
     {"projectID":1234162,"fileID":6734060,"___name":"Lumenized"                               ,"downloadUrl":"https://edge.forgecdn.net/files/6734/60/Lumenized-1.0.4.jar","required":true},
@@ -445,7 +446,6 @@
     {"projectID":1504502,"fileID":8001924,"___name":"XNet: Additions"                         ,"downloadUrl":"https://edge.forgecdn.net/files/8001/924/XNetAdditions-0.1.4.jar","required":true},
     {"projectID":1533287,"fileID":8035777,"___name":"ThaumicAPI"                              ,"downloadUrl":"https://edge.forgecdn.net/files/8035/777/thaumicapi-1.0.0.jar","required":true},
     {"projectID":1533544,"fileID":8037355,"___name":"Warp-O-Mania"                            ,"downloadUrl":"https://edge.forgecdn.net/files/8037/355/warpomania-1.0.0.jar","required":true},
-    {"projectID":1535236,"fileID":8053452,"___name":"Tinker's Planner Antique"                ,"downloadUrl":"https://edge.forgecdn.net/files/8053/452/TinkersPlannerAntique-1.12.2-1.0.2.jar","required":true},
-    {"projectID":1214490,"fileID":8073312,"___name":"Cleanroom Relauncher"                    ,"downloadUrl":"https://edge.forgecdn.net/files/8073/312/!cleanroom-relauncher-0.5.0.jar","required":true}
+    {"projectID":1535236,"fileID":8053452,"___name":"Tinker's Planner Antique"                ,"downloadUrl":"https://edge.forgecdn.net/files/8053/452/TinkersPlannerAntique-1.12.2-1.0.2.jar","required":true}
   ]
 }

--- a/server/server-setup-config.yaml
+++ b/server/server-setup-config.yaml
@@ -220,7 +220,7 @@ launch:
   # For Forge 1.12-: "forge-{{@mcversion@}}-{{@loaderversion@}}-universal.jar"
   # For Forge 1.13+: "forge-{{@mcversion@}}-{{@loaderversion@}}.jar"
   # For Fabric: "fabric-server-launch.jar"
-  startFile: 'forge-{{@mcversion@}}-{{@loaderversion@}}.jar'
+  startFile: 'cleanroom-0.5.12-alpha.jar'
 
   # This is the command how the server is supposed to be started
   # For <1.16 it should be

--- a/server/server-setup-config.yaml
+++ b/server/server-setup-config.yaml
@@ -128,6 +128,7 @@ install:
       - 1234162 # Lumenized
       - 1329068 # MorphOverlay
       - 1331377 # Armored Arms
+      - 1214490 # Cleanroom Relauncher
 
     # The base path where the server should be installed to, ~ for current path
   baseInstallPath: ~

--- a/server/server-setup-config.yaml
+++ b/server/server-setup-config.yaml
@@ -124,11 +124,11 @@ install:
       - 1132293 # Backpack Display
       - 1147522 # Backpack Opener
       - 1154099 # Crash Assistant
+      - 1214490 # Cleanroom Relauncher
       - 1220460 # Gnetum
       - 1234162 # Lumenized
       - 1329068 # MorphOverlay
       - 1331377 # Armored Arms
-      - 1214490 # Cleanroom Relauncher
 
     # The base path where the server should be installed to, ~ for current path
   baseInstallPath: ~

--- a/server/server-setup-config.yaml
+++ b/server/server-setup-config.yaml
@@ -220,7 +220,7 @@ launch:
   # For Forge 1.12-: "forge-{{@mcversion@}}-{{@loaderversion@}}-universal.jar"
   # For Forge 1.13+: "forge-{{@mcversion@}}-{{@loaderversion@}}.jar"
   # For Fabric: "fabric-server-launch.jar"
-  startFile: 'cleanroom-0.5.12-alpha.jar'
+  startFile: cleanroom-0.5.12-alpha.jar
 
   # This is the command how the server is supposed to be started
   # For <1.16 it should be

--- a/server/server-setup-config.yaml
+++ b/server/server-setup-config.yaml
@@ -22,7 +22,7 @@ install:
   # supports variables: {{@loaderversion@}} and {{@mcversion@}}
   # For forge: "http://files.minecraftforge.net/maven/net/minecraftforge/forge/{{@mcversion@}}-{{@loaderversion@}}/forge-{{@mcversion@}}-{{@loaderversion@}}-installer.jar"
   # For Fabric: "https://maven.fabricmc.net/net/fabricmc/fabric-installer/{{@loaderversion@}}/fabric-installer-{{@loaderversion@}}.jar"
-  installerUrl: 'https://files.minecraftforge.net/maven/net/minecraftforge/forge/{{@mcversion@}}-{{@loaderversion@}}/forge-{{@mcversion@}}-{{@loaderversion@}}-installer.jar'
+  installerUrl: 'https://github.com/CleanroomMC/Cleanroom/releases/download/0.5.12-alpha/cleanroom-0.5.12-alpha-installer.jar'
 
   # Installer Arguments
   # These Arguments have to be passed to the installer


### PR DESCRIPTION
This PR introduces Client side Cleanroom relaunching, is set on 0.5.12 version of cleanroom, with target JVM 25, and args set automatically.
Cleanroom Support is also added to server.
Already tried testing both client and server before opening PR, seems good.