### PR TITLE
Fix fracture generation

### DIFF
--- a/config/thaumicaugmentation.cfg
+++ b/config/thaumicaugmentation.cfg
@@ -421,8 +421,8 @@ world {
     # Lists the whitelisted dimensions for fractures (not including the Emptiness dim), and their associated weights.
     # The format for each line is dim=weight, with higher weights (compared to lower weights) being more likely to spawn.
     # This WILL affect worldgen, so use with caution on existing worlds.
-    # Default dimensions: 0 = Overworld, -1 = Nether, 1 = End, 7 = Twilight Forest, -8 = Ratlantis, -11325 = Deep Dark,
-	# 101 = Mercury, 102 = Venus
+    # Default dimensions: 0 = Overworld, -1 = Nether, 1 = End, 7 = Twilight Forest, 17 = Atum 2,
+    # 20 = Betweenlands, 111 = Lost Cities, 66 = Erebus, 33 = Wizardry (Underworld)
     S:FractureDimList <
         0=35
         -1=15

--- a/config/thaumicaugmentation.cfg
+++ b/config/thaumicaugmentation.cfg
@@ -421,14 +421,12 @@ world {
     # Lists the whitelisted dimensions for fractures (not including the Emptiness dim), and their associated weights.
     # The format for each line is dim=weight, with higher weights (compared to lower weights) being more likely to spawn.
     # This WILL affect worldgen, so use with caution on existing worlds.
-    # Default dimensions: 0 = Overworld, -1 = Nether, 1 = End, 7 = Twilight Forest, 17 = Atum 2,
-    # 20 = Betweenlands, 111 = Lost Cities, 66 = Erebus, 33 = Wizardry (Underworld)
+    # Default dimensions: 0 = Overworld, -1 = Nether, 1 = End, 7 = Twilight Forest
     S:FractureDimList <
         0=35
         -1=15
         1=10
         7=5
-        20=5
      >
 
     # The chance for a fracture to generate in a chunk in the Emptiness dimension.

--- a/config/thaumicaugmentation.cfg
+++ b/config/thaumicaugmentation.cfg
@@ -421,12 +421,17 @@ world {
     # Lists the whitelisted dimensions for fractures (not including the Emptiness dim), and their associated weights.
     # The format for each line is dim=weight, with higher weights (compared to lower weights) being more likely to spawn.
     # This WILL affect worldgen, so use with caution on existing worlds.
-    # Default dimensions: 0 = Overworld, -1 = Nether, 1 = End, 7 = Twilight Forest
+    # Default dimensions: 0 = Overworld, -1 = Nether, 1 = End, 7 = Twilight Forest, -8 = Ratlantis, -11325 = Deep Dark,
+	# 101 = Mercury, 102 = Venus
     S:FractureDimList <
         0=35
         -1=15
         1=10
         7=5
+		-8=5
+		-11325=5
+		101=5
+		102=5		
      >
 
     # The chance for a fracture to generate in a chunk in the Emptiness dimension.

--- a/config/thaumicaugmentation.cfg
+++ b/config/thaumicaugmentation.cfg
@@ -428,10 +428,7 @@ world {
         -1=15
         1=10
         7=5
-        17=5
         20=5
-        111=5
-        66=5
      >
 
     # The chance for a fracture to generate in a chunk in the Emptiness dimension.


### PR DESCRIPTION
Removed unused dimensions from config list.
Removed Proxima B (111) from dimension list. This was included as an error due to the ID 111 being shared with the Lost Cities mod.
I personally find the idea of using the Emptiness to crossover with other dimensions very cool, so being able to magically go to space dimensions is totally something I would support, but only Proxima B is obviously not intended.

Suggested Option 1: Ignore this pull request
Suggested Option 2: Accept this pull request and remove Proxima B.
Suggested Option 3: Add intentional, whacky dimensions like the Moon, Ratlantis, Deep Dark, etc. (I can do this if you don't want to take the time)