### PR TITLE
CreeperTrophy; Explosion Strength 2->3

### DIFF
--- a/scripts/mixin/openblocks_reopened.zs
+++ b/scripts/mixin/openblocks_reopened.zs
@@ -1,0 +1,7 @@
+#modloaded openblocks
+#loader mixin
+#mixin { targets: 'openblocks.trophy.CreeperBehavior' }
+zenClass MixinCreeperBehaviorConst {
+  #mixin ModifyConstant { method: 'executeActivateBehavior', constant: { floatValue: 2.0 } }
+  function changeCreeperExplosionPower(v as float) as float { return 3.0; }
+}

--- a/scripts/mixin/openblocks_reopened.zs
+++ b/scripts/mixin/openblocks_reopened.zs
@@ -1,3 +1,10 @@
+/*
+  A Creeper explosion power is 3, the default power of the CreeperTrophy explosion is 2.
+  This is not enough to convert the Basic Machine Casing, the Steel Casing, or the
+  Advanced Machine Casing to obtain machine parts with the "Exploding Blocks" recipes.
+  This increases the power of the CreeperTrophy to 3, which is enough. 
+*/
+
 #modloaded openblocks
 #loader mixin
 #mixin { targets: 'openblocks.trophy.CreeperBehavior' }


### PR DESCRIPTION
A creeper explosion has a power of 3 and a tnt explosion has a power of 4. The CreeperTrophy explosion has a power of 2, which is not sufficient enough to break the Basic Machine Casing, the Steel Casing, or the Advanced Machine Casing. This mixin simply increases the explosion power from 2 to 3, which will convert these casings into the appropriate machine parts.