### PR TITLE
Update Obscure Tooltips config to remedy mod conflicts

### DIFF
--- a/config/obscuria/obscure_tooltips-client.cfg
+++ b/config/obscuria/obscure_tooltips-client.cfg
@@ -55,6 +55,8 @@ general {
         botania:manatablet
         rftoolsdim:material_absorber
         enderio:item_soul_vial
+        thermalexpansion:morb
+        industrialforegoing:mob_imprisonment_tool
      >
 
     # Whether Obscure Tooltips should display the second line in the tooltip header.

--- a/config/obscuria/obscure_tooltips-client.cfg
+++ b/config/obscuria/obscure_tooltips-client.cfg
@@ -50,6 +50,9 @@ general {
         travelersbackpack:travelers_backpack
         thaumcraft:focus_pouch
         thaumictinkerer:focus_pouch
+        botania:manaring
+        botania:manaringgreater
+        botania:manatablet        
      >
 
     # Whether Obscure Tooltips should display the second line in the tooltip header.

--- a/config/obscuria/obscure_tooltips-client.cfg
+++ b/config/obscuria/obscure_tooltips-client.cfg
@@ -10,7 +10,46 @@ general {
     # List of item IDs that should be ignored by Obscure Tooltips.
     S:ignoredItems <
         quality_equipment:reforge_gui_button
+        minecraft:white_shulker_box
+        minecraft:orange_shulker_box
+        minecraft:magenta_shulker_box
+        minecraft:light_blue_shulker_box
+        minecraft:yellow_shulker_box
+        minecraft:lime_shulker_box
+        minecraft:pink_shulker_box
+        minecraft:gray_shulker_box
+        minecraft:silver_shulker_box
+        minecraft:cyan_shulker_box
+        minecraft:purple_shulker_box
+        minecraft:blue_shulker_box
+        minecraft:brown_shulker_box
+        minecraft:green_shulker_box
+        minecraft:red_shulker_box
+        minecraft:black_shulker_box
+        storagedrawers:basicdrawers
+        storagedrawers:customdrawers
+        storagedrawers:compdrawers
+        forestry:apiarist_bag
+        forestry:lepidopterist_bag
+        forestry:miner_bag
+        forestry:miner_bag_t2
+        forestry:digger_bag
+        forestry:digger_bag_t2
+        forestry:forester_bag
+        forestry:forester_bag_t2
+        forestry:hunter_bag
+        forestry:hunter_bag_t2
+        forestry:adventurer_bag
+        forestry:adventurer_bag_t2
+        forestry:builder_bag
+        forestry:builder_bag_t2
+        framedcompactdrawers:framed_compact_drawer
         cyclicmagic:storage_bag
+        spiceoflife:lunchbox
+        spiceoflife:lunchbag
+        travelersbackpack:travelers_backpack
+        thaumcraft:focus_pouch
+        thaumictinkerer:focus_pouch
      >
 
     # Whether Obscure Tooltips should display the second line in the tooltip header.

--- a/config/obscuria/obscure_tooltips-client.cfg
+++ b/config/obscuria/obscure_tooltips-client.cfg
@@ -52,7 +52,8 @@ general {
         thaumictinkerer:focus_pouch
         botania:manaring
         botania:manaringgreater
-        botania:manatablet        
+        botania:manatablet
+        rftoolsdim:material_absorber
      >
 
     # Whether Obscure Tooltips should display the second line in the tooltip header.

--- a/config/obscuria/obscure_tooltips-client.cfg
+++ b/config/obscuria/obscure_tooltips-client.cfg
@@ -10,6 +10,7 @@ general {
     # List of item IDs that should be ignored by Obscure Tooltips.
     S:ignoredItems <
         quality_equipment:reforge_gui_button
+        cyclicmagic:storage_bag
      >
 
     # Whether Obscure Tooltips should display the second line in the tooltip header.
@@ -30,6 +31,7 @@ general {
 model-preview {
     # List of item IDs that should never display a 3D armor preview.
     S:armorPreviewBlacklist <
+        entityculling
      >
 
     # Whether Obscure Tooltips should display 3D armor previews.

--- a/config/obscuria/obscure_tooltips-client.cfg
+++ b/config/obscuria/obscure_tooltips-client.cfg
@@ -62,6 +62,8 @@ general {
         trinity:light_container
         trinity:medium_container
         trinity:heavy_container
+        mekanism:cardboardbox
+        mekanism:basicblock
      >
 
     # Whether Obscure Tooltips should display the second line in the tooltip header.

--- a/config/obscuria/obscure_tooltips-client.cfg
+++ b/config/obscuria/obscure_tooltips-client.cfg
@@ -54,6 +54,7 @@ general {
         botania:manaringgreater
         botania:manatablet
         rftoolsdim:material_absorber
+        enderio:item_soul_vial
      >
 
     # Whether Obscure Tooltips should display the second line in the tooltip header.

--- a/config/obscuria/obscure_tooltips-client.cfg
+++ b/config/obscuria/obscure_tooltips-client.cfg
@@ -57,6 +57,11 @@ general {
         enderio:item_soul_vial
         thermalexpansion:morb
         industrialforegoing:mob_imprisonment_tool
+        my_precious:rubble
+        randomthings:enderletter
+        trinity:light_container
+        trinity:medium_container
+        trinity:heavy_container
      >
 
     # Whether Obscure Tooltips should display the second line in the tooltip header.


### PR DESCRIPTION
The Obscure Tooltips mod has been found to conflict with a few mods, luckily these issues can be resolved by simple changes made to the configuration file.

Obscure Tooltips breaks the inventory overlay for the Cyclic (see image). When the Storage Bag is hovered over, there is an overlay showing oddly ordered numbers and percentage bars, without the icons to indicate what they are. Ignoring the Storage Bag in the configuration prevents this behavior and restores the 4 rows of icons and a +howevermanymoreitemsthereare number in the bottom right corner.

While it isn't included in the pack by default, a number of users use the EntityCulling mod to help improve performance. It appears that the 3D model viewer for equipment included with Obscure Tooltips conflicts with EntityCulling, creating a blue overlay that flashes/strobes (potentially seizure inducing?) while the 3D model is visible. It doesn't seem like this is an issue for Tools, just Armor. Adding "entityculling" to the armorPreviewBlacklist appears to prevent the mod from interacting with Obscure Tooltips entirely- preventing the blue strobing effect. This does nothing for users that don't use EntityCulling, so there isn't any harm in including it.

Both of these changes have been tested by myself and at least 1 other user to confirm the behavior is corrected. I expect as more people play the updated version, more conflicts will arise and hopefully many of them can be easily corrected in the same way.

<img width="1588" height="1080" alt="ObscureTooltips" src="https://github.com/user-attachments/assets/11e70d25-466a-4477-bb6f-1a4816d88cc0" />
