### PR TITLE
Replicator: Using all fuel, set to 0 instead of null

### DIFF
--- a/scripts/requious/replicator.zs
+++ b/scripts/requious/replicator.zs
@@ -272,7 +272,7 @@ function consumeMatter(m as MachineContainer, consumeAmount as int) as bool {
   if (isNull(fluid) || fluid.amount <= 0) return false;
   m.setFluid(mattX, mattY, fluid.amount > consumeAmount
     ? fluid * (fluid.amount - consumeAmount)
-    : null
+    : fluid * 0
   );
   val uuid = m.getString('ownerUUID');
   val oldValue = scripts.lib.offline.op.get(uuid, 'stat_replications', 0) as int;


### PR DESCRIPTION
@FF_data in Discord had an issue where the Replicator was crashing their world when running out of UU matter and AI proposed a fix that worked. In the script being modified, if all of the UU matter in the Replicator will be used up, the fluid is set to null, which causes an immediate crash of the world, kicking you back to the main screen. After that, you can no longer enter the world because it will produce the same crash.

I assume the idea is to clear out the fluid entirely if there isn't any left, which would make sense for a container- but the Fabricator only accepts and only uses UU matter so instead of removing the fluid entirely, setting it to 0 does make sense. When this change is applied, the Fabricator won't show 0 UU Matter when empty, it will still simply say Empty.

I recreated the crash scenario, which is simply replicating something that requires more than, or the exact amount of UU matter in the Replicator. I also tested the change and it fixes the behavior. I tested:

1. Less than required UU matter
2. Exact amount of UU required
3. More than UU required

Exact gets used up fine, less than uses whats available and waits for more and will complete when the correct amount is provided, and excess UU matter uses up whats needed and leaves the remainder as expected.

**Log of Error**
https://mclo.gs/N7yHsUN